### PR TITLE
🎨 Palette: Add empty state and page metadata

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-28 - Empty State Implementation
+**Learning:** The Streamlit file uploader returns `None` or an empty list when no files are uploaded. This provides a natural branching point (`if files:` vs `else:`) to implement an empty state without complex state management.
+**Action:** Always check if a file uploader or similar input has data before rendering the main UI, and provide an `st.info` or similar call-to-action when it's empty to guide the user.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,7 +1,7 @@
 import math
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import altair as alt
 import matplotlib.pyplot as plt
@@ -9,10 +9,13 @@ import openfoam_residuals.filesystem as fs
 import openfoam_residuals.plot as orp
 import pandas as pd
 import streamlit as st
-from streamlit.delta_generator import DeltaGenerator
 
 # Page configuration
-st.set_page_config(layout="centered")
+st.set_page_config(
+    page_title="OpenFOAM Residuals",
+    page_icon="📈",
+    layout="centered"
+)
 
 
 def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
@@ -165,6 +168,8 @@ def main() -> None:
                         st.subheader(f"File: {item['name']}")
                     data, _ = fs.pre_parse(item['path'])
                     st.dataframe(data)
+    else:
+        st.info("👋 Welcome! Please upload your `residual.dat` files using the uploader above to get started.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 **What:** 
- Configured the Streamlit app to use a descriptive `page_title` ("OpenFOAM Residuals") and `page_icon` ("📈").
- Added an empty state message (`st.info`) that displays when no files have been uploaded yet.
- Fixed a couple of unused imports.

🎯 **Why:** 
- The default browser tab title "streamlit_app" is not descriptive. A proper title helps users identify the tab easily.
- When a user first opens the application, they are greeted with just an upload box and a blank space below it. The empty state message provides clear instructions on what they are expected to do next, making the application feel more complete and welcoming.

📸 **Before/After:** 
- *Before*: The app opened to an upload widget with nothing below it, and the browser tab was named "streamlit_app".
- *After*: The browser tab is "OpenFOAM Residuals 📈". Below the uploader, a friendly message says "👋 Welcome! Please upload your `residual.dat` files using the uploader above to get started."

♿ **Accessibility:** 
- Provides immediate text feedback/guidance on the required interaction when the application loads.

---
*PR created automatically by Jules for task [16178645728680631186](https://jules.google.com/task/16178645728680631186) started by @kastnerp*