### PR TITLE
🎨 Palette: Make Altair charts interactive and format tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-28 - Empty State Implementation
 **Learning:** The Streamlit file uploader returns `None` or an empty list when no files are uploaded. This provides a natural branching point (`if files:` vs `else:`) to implement an empty state without complex state management.
 **Action:** Always check if a file uploader or similar input has data before rendering the main UI, and provide an `st.info` or similar call-to-action when it's empty to guide the user.
+
+## 2025-03-02 - Altair Chart Interactivity in Streamlit
+**Learning:** Altair charts rendered in Streamlit are static by default, meaning users cannot zoom or pan through large datasets (like thousands of residual iterations). Adding `.interactive()` to the Altair chart object transforms it into a fully explorable visualization.
+**Action:** When using Altair in Streamlit for timeseries or large datasets where exploration is key, always chain `.interactive()` to the chart definition. Additionally, explicitly format tooltips for tiny numbers (e.g., `alt.Tooltip('Value:Q', format='.2e')`) to maintain readability.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -39,11 +39,11 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
         x=alt.X('Time:Q', title='Iteration'),  # Use the 'Time' column for the x-axis
         y=alt.Y('Value:Q', scale=alt.Scale(type='log'), title='Residuals'),
         color=alt.Color('Residual:N', title='Variable'),
-        tooltip=['Time', 'Residual', 'Value']  # Update tooltip to use 'Time'
+        tooltip=['Time', 'Residual', alt.Tooltip('Value:Q', format='.2e')]  # Update tooltip to use 'Time'
     ).properties(
         width=800,
         height=400
-    )
+    ).interactive()
 
     return chart
 


### PR DESCRIPTION
💡 What: Added `.interactive()` to the Altair chart generated in `create_altair_plot` and formatted the `Value` tooltip to display scientific notation (`.2e`).
🎯 Why: Altair charts in Streamlit are static by default. Given that residual plots often contain thousands of data points and very small values, allowing users to zoom and pan makes the charts significantly more useful. Formatting the tooltip ensures that tiny floating-point numbers remain legible.
📸 Before/After: See attached screenshots from the frontend verification.
♿ Accessibility: N/A - Improves general UX by providing interactive data exploration.

---
*PR created automatically by Jules for task [14028192140696494167](https://jules.google.com/task/14028192140696494167) started by @kastnerp*