### PR TITLE
🎨 Palette: [Improve Altair chart readability and interactivity]

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -42,11 +42,11 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
         x=alt.X('Time:Q', title='Iteration'),  # Use the 'Time' column for the x-axis
         y=alt.Y('Value:Q', scale=alt.Scale(type='log'), title='Residuals'),
         color=alt.Color('Residual:N', title='Variable'),
-        tooltip=[alt.Tooltip('Time:Q'), alt.Tooltip('Residual:N'), alt.Tooltip('Value:Q')]  # Update tooltip to use 'Time'
+        tooltip=[alt.Tooltip('Time:Q'), alt.Tooltip('Residual:N'), alt.Tooltip('Value:Q', format='.2e')]  # Update tooltip to use 'Time'
     ).properties(
         width=800,
         height=400
-    )
+    ).interactive()
 
     return chart
 


### PR DESCRIPTION
💡 **What:** The UX enhancement added interactive features (zoom/pan) to the Altair chart and formatted the tooltip values for residuals.
🎯 **Why:** OpenFOAM residuals often contain very small numbers (e.g., 1e-05) that can be hard to read when displayed as long decimals in tooltips. Formatting them as scientific notation (`.2e`) improves readability. Additionally, chaining `.interactive()` enables zooming and panning, which is crucial for exploring dense time-series or iteration data effectively.
📸 **Before/After:** The chart now supports zooming/panning and tooltips display numbers cleanly as e.g. `1.00e-05`.
♿ **Accessibility:** Makes tiny numbers easier to read, reducing cognitive load for users inspecting chart details.

---
*PR created automatically by Jules for task [29795103583456345](https://jules.google.com/task/29795103583456345) started by @kastnerp*