### PR TITLE
🎨 Palette: Use functional names instead of library names for tabs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-28 - Empty State Implementation
 **Learning:** The Streamlit file uploader returns `None` or an empty list when no files are uploaded. This provides a natural branching point (`if files:` vs `else:`) to implement an empty state without complex state management.
 **Action:** Always check if a file uploader or similar input has data before rendering the main UI, and provide an `st.info` or similar call-to-action when it's empty to guide the user.
+
+## 2026-03-04 - User-Centric Labeling
+**Learning:** Using technical implementation details (like "Altair", "Matplotlib", "Dataframe") for UI elements (like tab names) creates unnecessary cognitive load for users who only care about the functionality (e.g., interactive plotting, static plotting, viewing raw data).
+**Action:** Always replace technical jargon with functional, user-centric language that clearly describes what the user can do or see, regardless of the underlying libraries used.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -111,8 +111,8 @@ def main() -> None:
     # Sidebar controls
     with st.sidebar:
         st.subheader("Plot Settings")
-        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the Matplotlib figure in inches.")
-        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the Matplotlib figure in inches.")
+        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the static plot in inches.")
+        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the static plot in inches.")
         show_filenames = st.checkbox('Show Filenames', value=False)
 
     # File uploader
@@ -126,9 +126,9 @@ def main() -> None:
     if files:
         # Create tabs
         tab1, tab2, tab3 = st.tabs([
-            "📊 Altair",
-            "📈 Matplotlib",
-            "📋 Dataframe"
+            "📊 Interactive Plot",
+            "📈 Static Plot",
+            "📋 Raw Data"
         ])
 
         # Parse files once and cache results to reduce redundant file reading


### PR DESCRIPTION
💡 **What**: Changed Streamlit tab names from "Altair", "Matplotlib", and "Dataframe" to "Interactive Plot", "Static Plot", and "Raw Data" respectively. Updated corresponding sidebar tooltips.
🎯 **Why**: Using technical implementation details for UI elements creates unnecessary cognitive load for users who only care about the functionality they are getting, not the Python libraries used under the hood. This change makes the UI more intuitive and descriptive.
📸 **Before/After**: See the attached playwright screenshot where the new tabs are displayed.
♿ **Accessibility**: N/A, but it improves general usability and intuitiveness by standardizing on plain English names.

---
*PR created automatically by Jules for task [10081097934457226843](https://jules.google.com/task/10081097934457226843) started by @kastnerp*