### PR TITLE
🎨 Palette: Update tooltips and sidebar labels for better UX

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -42,7 +42,7 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
         x=alt.X('Time:Q', title='Iteration'),  # Use the 'Time' column for the x-axis
         y=alt.Y('Value:Q', scale=alt.Scale(type='log'), title='Residuals'),
         color=alt.Color('Residual:N', title='Variable'),
-        tooltip=[alt.Tooltip('Time:Q'), alt.Tooltip('Residual:N'), alt.Tooltip('Value:Q', format='.2e')]  # Update tooltip to use 'Time'
+        tooltip=[alt.Tooltip('Time:Q', title='Iteration'), alt.Tooltip('Residual:N', title='Variable'), alt.Tooltip('Value:Q', title='Residual', format='.2e')]  # Update tooltip to use 'Time'
     ).properties(
         width=800,
         height=400
@@ -116,9 +116,9 @@ def main() -> None:
     # Sidebar controls
     with st.sidebar:
         st.subheader("Plot Settings")
-        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the Matplotlib figure in inches.")
-        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the Matplotlib figure in inches.")
-        dpi = st.number_input('Figure DPI', min_value=50, max_value=600, value=150, help="Resolution of the Matplotlib figure. Lower values render faster.")
+        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the static plot in inches.")
+        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the static plot in inches.")
+        dpi = st.number_input('Figure DPI', min_value=50, max_value=600, value=150, help="Resolution of the static plot. Lower values render faster.")
         show_filenames = st.checkbox('Show Filenames', value=False)
 
     # File uploader


### PR DESCRIPTION
**💡 What**: 
- Updated the help text in the sidebar for `Figure Width`, `Figure Height`, and `Figure DPI` to use the term "static plot" instead of referring to the implementation detail ("Matplotlib figure").
- Added user-friendly `title` attributes to the Altair tooltips in the interactive plot so that users see descriptive labels (e.g., "Iteration" instead of the raw column name "Time", and "Residual" instead of "Value").

**🎯 Why**: 
- Using technical jargon like "Matplotlib figure" increases cognitive load for users who just want to adjust the plot. Using functional language like "static plot" makes the interface much more intuitive.
- The raw data column names in the Altair tooltips were not perfectly descriptive. Adding explicit titles ensures the tooltips align with the chart's axis labels and clearly explain the data points to the user.

**📸 Before/After**: 
*Before*: Tooltips showed `Time`, `Residual`, `Value`. Sidebar help text mentioned `Matplotlib figure`.
*After*: Tooltips show `Iteration`, `Variable`, `Residual`. Sidebar help text mentions `static plot`.

**♿ Accessibility**: 
Improves general usability and clarity for all users by removing implementation-specific terminology and making data labels more descriptive.

---
*PR created automatically by Jules for task [2626936051682084844](https://jules.google.com/task/2626936051682084844) started by @kastnerp*