### PR TITLE
🎨 Palette: Improve settings grouping and multi-file layout

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -139,11 +139,15 @@ def main() -> None:
 
     # Sidebar controls
     with st.sidebar:
-        st.subheader("Plot Settings")
+        st.subheader("📈 Static Plot Settings")
         width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the static plot in inches.")
         height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the static plot in inches.")
         dpi = st.number_input('Figure DPI', min_value=50, max_value=600, value=150, help="Resolution of the static plot. Lower values render faster.")
-        show_filenames = st.checkbox('Show Filenames', value=False)
+
+        st.divider()
+
+        st.subheader("⚙️ General Settings")
+        show_filenames = st.checkbox('Show Filenames', value=False, help="Display the filename above each plot when comparing multiple files.")
 
     # File uploader
     files = st.file_uploader(
@@ -177,7 +181,9 @@ def main() -> None:
 
         # Altair plots
         with tab1:
-            for item in parsed_files:
+            for i, item in enumerate(parsed_files):
+                if i > 0:
+                    st.divider()
                 if show_filenames:
                     st.subheader(f"File: {item['name']}")
                 chart = create_altair_plot(item['data'])
@@ -185,7 +191,9 @@ def main() -> None:
 
         # Matplotlib plots
         with tab2:
-            for item in parsed_files:
+            for i, item in enumerate(parsed_files):
+                if i > 0:
+                    st.divider()
                 if show_filenames:
                     st.subheader(f"File: {item['name']}")
                 data = item['data']
@@ -196,7 +204,9 @@ def main() -> None:
 
         # Raw data
         with tab3:
-            for item in parsed_files:
+            for i, item in enumerate(parsed_files):
+                if i > 0:
+                    st.divider()
                 if show_filenames:
                     st.subheader(f"File: {item['name']}")
                 st.dataframe(item['data'])


### PR DESCRIPTION
💡 **What**:
- Grouped static plot settings and general settings with clear subheaders in the sidebar.
- Added a helpful tooltip to the "Show Filenames" checkbox to explain its use.
- Added visual dividers (`st.divider()`) between files in the plot and data tabs when multiple files are uploaded.

🎯 **Why**:
- Grouping settings clarifies that width, height, and DPI only affect the static Matplotlib plot, reducing user confusion.
- The tooltip explains the context of the "Show Filenames" checkbox.
- The dividers provide essential visual separation between datasets, particularly when multiple files are uploaded and the "Show Filenames" checkbox is unchecked.

♿ **Accessibility**:
- Tooltips provide additional context for screen readers and users unsure of the checkbox's function.
- Visual separation improves cognitive processing of distinct datasets.

---
*PR created automatically by Jules for task [116737342301386959](https://jules.google.com/task/116737342301386959) started by @kastnerp*