### PR TITLE
🎨 Palette: Add file upload success toast & full-width dataframes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,11 @@
 ## 2024-03-05 - Graceful Error States for File Uploads
 **Learning:** In Streamlit applications, failing to catch parsing errors on file uploads causes a stack trace that blocks the entire UI.
 **Action:** Always wrap file upload processing logic in `try...except` blocks and use `st.error` to provide actionable feedback instead of crashing. Accompany this with `st.spinner` to provide loading feedback.
+
+## 2026-03-05 - Ephemeral Notifications
+**Learning:** Streamlit UI interactions (like toggling a checkbox) rerun the entire script. If a notification like `st.toast` or `st.balloons` is placed conditionally inside a block that runs (like checking if files are uploaded), it will fire on *every* interaction, creating an annoying experience.
+**Action:** Always guard ephemeral UI notifications using `st.session_state` to track the specific items (e.g., file IDs) that triggered them, ensuring the notification only appears for *new* events.
+
+## 2026-03-05 - Responsive Dataframes
+**Learning:** By default, Streamlit's `st.dataframe` does not expand to the full container width, often leading to cramped tables and awkward white space that doesn't align with full-width charts above them.
+**Action:** Use `st.dataframe(data, use_container_width=True)` to ensure tables fill the available horizontal space, improving readability and layout consistency.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -136,6 +136,9 @@ def parse_uploaded_file(file_name: str, file_id: str, _file_content: bytes) -> t
 
 def main() -> None:
     """Main function to run the Streamlit application."""
+    if 'processed_files' not in st.session_state:
+        st.session_state.processed_files = set()
+
     st.header("Plot OpenFOAM Residuals")
 
     # Sidebar controls
@@ -172,6 +175,11 @@ def main() -> None:
 
         if not parsed_files:
             return
+
+        new_file_ids = {f['file_id'] for f in parsed_files}
+        if new_file_ids - st.session_state.processed_files:
+            st.toast("Files processed successfully!", icon="✅")
+            st.session_state.processed_files = new_file_ids
 
         # Create tabs
         tab1, tab2, tab3 = st.tabs([
@@ -216,7 +224,7 @@ def main() -> None:
                     st.divider()
                 if show_filenames:
                     st.subheader(f"File: {item['name']}")
-                st.dataframe(item['data'])
+                st.dataframe(item['data'], use_container_width=True)
     else:
         st.info("👋 Welcome! Please upload your `residual.dat` files using the uploader above to get started.")
 


### PR DESCRIPTION
💡 **What:** Added a success toast notification when files are parsed and made the Raw Data table expand to the full container width.
🎯 **Why:** 
1. The toast provides immediate, non-intrusive feedback that the application has successfully digested the files and is ready for exploration, which is especially helpful if parsing takes a moment. By utilizing `st.session_state` to track file IDs, the toast only appears for *new* uploads, rather than annoyingly popping up every time a user toggles a sidebar checkbox (which triggers a Streamlit rerun).
2. Setting `use_container_width=True` on the dataframe prevents it from looking cramped and awkward, ensuring it aligns visually with the full-width charts above it.

📸 **Before/After:**
*   **Before:** Silent uploads; dataframe is squeezed to the left with empty space on the right.
*   **After:** A polite "Files processed successfully! ✅" toast appears; dataframe stretches to use all available horizontal space.

♿ **Accessibility:** The `st.toast` automatically handles ARIA live region announcements, ensuring screen reader users are notified when their files are ready. Full-width tables reduce horizontal scrolling for users with low vision or magnified screens.

---
*PR created automatically by Jules for task [13607495045470157606](https://jules.google.com/task/13607495045470157606) started by @kastnerp*