### PR TITLE
🎨 Palette: Add interactive legend to Altair residual plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2026-03-05 - Responsive Dataframes
 **Learning:** By default, Streamlit's `st.dataframe` does not expand to the full container width, often leading to cramped tables and awkward white space that doesn't align with full-width charts above them.
 **Action:** Use `st.dataframe(data, use_container_width=True)` to ensure tables fill the available horizontal space, improving readability and layout consistency.
+
+## 2026-03-05 - Interactive Legends in Dense Plots
+**Learning:** For line charts with multiple series (like plotting various OpenFOAM residuals), static plots often become visually overwhelming and unreadable as lines overlap.
+**Action:** Always enhance UX by implementing interactive legends using `alt.selection_point(bind='legend')` with conditional opacity. This allows users to isolate specific variables dynamically without the need for additional UI controls like checkboxes, reducing visual clutter.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -37,6 +37,11 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
     # 1. Eliminates O(N) DataFrame melting on the backend, saving CPU time.
     # 2. Reduces backend memory footprint and the JSON payload size sent to the frontend by ~6x
     #    because we send the wide DataFrame instead of a 6x longer melted DataFrame.
+    # 🎨 Palette Improvement: Interactive Legend
+    # Allows users to click legend items to isolate specific variables
+    # This improves readability of dense, overlapping residual plots without adding UI clutter
+    selection = alt.selection_point(fields=['Residual'], bind='legend')
+
     chart = alt.Chart(data_reset).transform_fold(
         ['Ux', 'Uy', 'Uz', 'p', 'epsilon', 'k'],
         as_=['Residual', 'Value']
@@ -44,7 +49,10 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
         x=alt.X('Time:Q', title='Iteration'),  # Use the 'Time' column for the x-axis
         y=alt.Y('Value:Q', scale=alt.Scale(type='log'), title='Residuals'),
         color=alt.Color('Residual:N', title='Variable'),
+        opacity=alt.condition(selection, alt.value(1), alt.value(0.2)),
         tooltip=[alt.Tooltip('Time:Q', title='Iteration'), alt.Tooltip('Residual:N', title='Variable'), alt.Tooltip('Value:Q', title='Residual', format='.2e')]  # Update tooltip to use 'Time'
+    ).add_params(
+        selection
     ).properties(
         width=800,
         height=400


### PR DESCRIPTION
💡 **What:** Added an interactive legend to the Altair charts using `alt.selection_point` and conditional opacity.
🎯 **Why:** Dense line plots (like OpenFOAM residuals with Ux, Uy, Uz, p, epsilon, k) easily become visually overwhelming. This allows users to click on any variable in the legend to isolate it (dimming the rest) without needing extra UI controls.
📸 **Before/After:** Before, users could not isolate lines on the interactive plot. Now, clicking "Ux" keeps it fully opaque while dropping the opacity of other variables to 0.2.
♿ **Accessibility:** Reduces visual clutter and cognitive load by allowing users to focus on specific data trends dynamically.

Also logged this insight to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [16621927886916001964](https://jules.google.com/task/16621927886916001964) started by @kastnerp*