### PR TITLE
🎨 Palette: Fix silent data omission with dynamic variable parsing

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-03-05 - Interactive Legends in Dense Plots
 **Learning:** For line charts with multiple series (like plotting various OpenFOAM residuals), static plots often become visually overwhelming and unreadable as lines overlap.
 **Action:** Always enhance UX by implementing interactive legends using `alt.selection_point(bind='legend')` with conditional opacity. This allows users to isolate specific variables dynamically without the need for additional UI controls like checkboxes, reducing visual clutter.
+
+## 2026-03-05 - Dynamic Variable Parsing
+**Learning:** Hardcoding expected variables (e.g., `['Ux', 'Uy', 'Uz', 'p', 'epsilon', 'k']`) when creating plots in Streamlit using Altair's `.transform_fold()` leads to silent data omission if the user uploads a dataset with different variables (like `omega` or `nuTilda`), which degrades trust and usability.
+**Action:** Always use dynamic column references (e.g., `list(data.columns)`) when transforming and plotting user-uploaded datasets to ensure all variables are robustly parsed and displayed, accommodating diverse user data.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -43,7 +43,7 @@ def create_altair_plot(data: pd.DataFrame) -> alt.Chart:
     selection = alt.selection_point(fields=['Residual'], bind='legend')
 
     chart = alt.Chart(data_reset).transform_fold(
-        ['Ux', 'Uy', 'Uz', 'p', 'epsilon', 'k'],
+        list(data.columns),
         as_=['Residual', 'Value']
     ).mark_line(point=False).encode(
         x=alt.X('Time:Q', title='Iteration'),  # Use the 'Time' column for the x-axis

--- a/test_residual.dat
+++ b/test_residual.dat
@@ -1,0 +1,4 @@
+# OpenFOAM
+# Time alpha beta gamma
+1 0.1 0.2 0.3
+2 0.01 0.02 0.03


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded list of variables (`['Ux', 'Uy', 'Uz', 'p', 'epsilon', 'k']`) in Altair's `.transform_fold()` with a dynamic reference `list(data.columns)`.
🎯 **Why:** Previously, if a user uploaded an OpenFOAM residual dataset containing different variables, those specific columns would be silently ignored by the interactive plot. This creates confusion and degrades the trustworthiness of the UI. By dynamically passing the column list, the plot now robustly adapts to any uploaded residual dataset.
📸 **Before/After:** The plot can now properly display non-standard residuals like `alpha`, `beta`, and `gamma` dynamically.
♿ **Accessibility:** This improves overall usability by ensuring all uploaded data is immediately available for exploration without hidden errors.

---
*PR created automatically by Jules for task [17146387031420047938](https://jules.google.com/task/17146387031420047938) started by @kastnerp*