### PR TITLE
🎨 Palette: Add discoverable download button for static plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -24,3 +24,7 @@
 ## 2026-03-05 - Dynamic Variable Parsing
 **Learning:** Hardcoding expected variables (e.g., `['Ux', 'Uy', 'Uz', 'p', 'epsilon', 'k']`) when creating plots in Streamlit using Altair's `.transform_fold()` leads to silent data omission if the user uploads a dataset with different variables (like `omega` or `nuTilda`), which degrades trust and usability.
 **Action:** Always use dynamic column references (e.g., `list(data.columns)`) when transforming and plotting user-uploaded datasets to ensure all variables are robustly parsed and displayed, accommodating diverse user data.
+
+## 2026-03-11 - Export Options for Generated Content
+**Learning:** For web applications that generate visual content (like high-quality static Matplotlib plots), users naturally expect to be able to save them. Relying entirely on browser functionality like "Right Click -> Save Image As" is undiscoverable and often provides a poor user experience, especially if the underlying image is displayed differently (e.g., within an `st.image` wrapper that might alter its natural behavior).
+**Action:** Always provide explicit, discoverable export options (like `st.download_button`) below generated visualizations, ensuring the downloaded file has a meaningful, pre-populated filename (e.g., incorporating the original uploaded filename).

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -233,6 +233,17 @@ def main() -> None:
                 img_bytes = get_matplotlib_image_bytes(data, item['file_id'], width, height, dpi)
                 st.image(img_bytes)
 
+                # 🎨 Palette Improvement: Export Options
+                # Allowing users to directly download the generated plot improves UX over relying
+                # on browser "Save Image As..." functionality.
+                st.download_button(
+                    label=f"Download {item['name']} Plot",
+                    data=img_bytes,
+                    file_name=f"{item['name'].replace('.dat', '')}_plot.png",
+                    mime="image/png",
+                    icon=":material/download:"
+                )
+
         # Raw data
         with tab3:
             for i, item in enumerate(parsed_files):


### PR DESCRIPTION
💡 **What**: Added an `st.download_button` under each generated Matplotlib static plot. The button allows the user to directly download the PNG image to their machine, with a pre-populated file name based on the original data file.

🎯 **Why**: When generating high-quality static Matplotlib visualizations, users naturally want to export them. Currently, users are forced to rely on the browser's "Right-click -> Save image as..." functionality. This interaction pattern is poorly discoverable, unintuitive, and relies on external browser behavior rather than intentional app design. Providing an explicit "Download Plot" button makes the export action highly visible, functional, and accessible. 

📸 **Before/After**:
*Before*: The Matplotlib plot simply displayed on the screen with no interaction options.
*After*: The Matplotlib plot displays with a clear "Download [Filename] Plot" button located directly beneath it, featuring a standard download icon.

♿ **Accessibility**: Replaces an undiscoverable context-menu interaction (which can be difficult to trigger for keyboard-only or screen reader users) with a standard HTML-based button element that receives focus natively and has a clear text label (`Download test_residual.dat Plot`).

---
*PR created automatically by Jules for task [7626037972724915729](https://jules.google.com/task/7626037972724915729) started by @kastnerp*