### PR TITLE
🎨 Palette: Add contextual disabled states to plot settings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -32,3 +32,7 @@
 ## 2024-03-05 - Grid Lines for Log-Scale Plots
 **Learning:** Static log-scale plots (like OpenFOAM residuals) are notoriously difficult to read without grid lines, as users struggle to trace data points back to the axis across large empty spaces.
 **Action:** Always include subtle grid lines (`ax.grid(True, which="both", alpha=0.5)`) on generated static plots, especially those using logarithmic scales, to significantly improve visual accessibility and data tracking.
+
+## 2026-03-13 - Contextual Disabled States and Tooltips
+**Learning:** Using progressive disclosure and conditionally disabling sidebar inputs until prerequisite data (like an uploaded file) is provided significantly improves UX. Users aren't left guessing why changing a setting has no effect, especially when paired with a contextual tooltip explaining *why* the input is disabled.
+**Action:** Always conditionally disable input controls that depend on uploaded data, and replace the standard `help` text with a clear, actionable explanation (e.g., "⚠️ Please upload a residual file first to enable this setting.") while the input is in a disabled state.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -168,19 +168,6 @@ def main() -> None:
 
     st.header("Plot OpenFOAM Residuals")
 
-    # Sidebar controls
-    with st.sidebar:
-        st.subheader("📈 Static Plot Settings")
-        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the static plot in inches.")
-        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the static plot in inches.")
-        dpi = st.number_input('Figure DPI', min_value=50, max_value=600, value=150, help="Resolution of the static plot. Lower values render faster.")
-        show_grid = st.checkbox('Show Grid Lines', value=True, help="Display subtle grid lines on the static plot to improve readability.")
-
-        st.divider()
-
-        st.subheader("⚙️ General Settings")
-        show_filenames = st.checkbox('Show Filenames', value=False, help="Display the filename above each plot when comparing multiple files.")
-
     # File uploader
     files = st.file_uploader(
         "Upload 'residual.dat' files here",
@@ -188,6 +175,20 @@ def main() -> None:
         accept_multiple_files=True,
         help="Files should be located in the _postProcessing_ folder of the OpenFOAM case."
     )
+    has_files = bool(files)
+
+    # Sidebar controls
+    with st.sidebar:
+        st.subheader("📈 Static Plot Settings")
+        width = st.number_input('Figure Width', min_value=1, value=10, help="Width of the static plot in inches." if has_files else "⚠️ Please upload a residual file first to enable this setting.", disabled=not has_files)
+        height = st.number_input('Figure Height', min_value=1, value=4, help="Height of the static plot in inches." if has_files else "⚠️ Please upload a residual file first to enable this setting.", disabled=not has_files)
+        dpi = st.number_input('Figure DPI', min_value=50, max_value=600, value=150, help="Resolution of the static plot. Lower values render faster." if has_files else "⚠️ Please upload a residual file first to enable this setting.", disabled=not has_files)
+        show_grid = st.checkbox('Show Grid Lines', value=True, help="Display subtle grid lines on the static plot to improve readability." if has_files else "⚠️ Please upload a residual file first to enable this setting.", disabled=not has_files)
+
+        st.divider()
+
+        st.subheader("⚙️ General Settings")
+        show_filenames = st.checkbox('Show Filenames', value=False, help="Display the filename above each plot when comparing multiple files." if has_files else "⚠️ Please upload a residual file first to enable this setting.", disabled=not has_files)
 
     if files:
         # Parse files once and cache results to reduce redundant file reading


### PR DESCRIPTION
💡 **What:** Added conditional `disabled` states to the plot settings in the sidebar. The settings are now inactive and display a helpful tooltip until a residual file is uploaded.
🎯 **Why:** Prevents users from trying to interact with settings that have no effect without uploaded data, reducing confusion. The updated tooltips guide users on what action they need to take.
📸 **Before/After:** Before, users could toggle settings without any visual change or feedback. Now, settings are visibly grayed out until a file is present.
♿ **Accessibility:** Improves cognitive accessibility by explicitly mapping UI elements to application state and required actions.

---
*PR created automatically by Jules for task [2739292272607589597](https://jules.google.com/task/2739292272607589597) started by @kastnerp*