### PR TITLE
🎨 Palette: Add final convergence summary and format raw data table

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2026-03-13 - Contextual Disabled States and Tooltips
 **Learning:** Using progressive disclosure and conditionally disabling sidebar inputs until prerequisite data (like an uploaded file) is provided significantly improves UX. Users aren't left guessing why changing a setting has no effect, especially when paired with a contextual tooltip explaining *why* the input is disabled.
 **Action:** Always conditionally disable input controls that depend on uploaded data, and replace the standard `help` text with a clear, actionable explanation (e.g., "⚠️ Please upload a residual file first to enable this setting.") while the input is in a disabled state.
+
+## 2026-03-14 - Data Summarization & Formatting in Tables
+**Learning:** Presenting a raw, massive dataset (like OpenFOAM residuals) directly in a table is overwhelming and unhelpful for the user's primary goal, which is usually assessing the final convergence state. Users are forced to scroll past thousands of rows to find the only information they care about. Additionally, raw floating-point numbers often display poorly without consistent formatting.
+**Action:** Always provide a high-level summary (e.g., using `st.metric` cards) of the most important data points (like the final iteration values) *above* the raw data table. Furthermore, use tools like `st.column_config` to enforce consistent, readable formatting (e.g., scientific notation `%.4e` for residuals) across the entire dataframe to improve scannability and professional polish.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -261,7 +261,30 @@ def main() -> None:
                     st.divider()
                 if show_filenames:
                     st.subheader(f"File: {item['name']}")
-                st.dataframe(item['data'], use_container_width=True)
+
+                # 🎨 Palette Improvement: Final Convergence Summary & Data Formatting
+                # Providing a quick summary of the final iteration values helps users instantly
+                # assess convergence without scrolling to the bottom of a massive table.
+                # Formatting the dataframe columns to scientific notation improves readability.
+                st.caption(f"Final Convergence (Iteration {item['data'].index[-1]})")
+
+                # Create a row of metrics for the last iteration
+                cols = st.columns(len(item['data'].columns))
+                last_row = item['data'].iloc[-1]
+                for col_idx, col_name in enumerate(item['data'].columns):
+                    with cols[col_idx]:
+                        val = last_row[col_name]
+                        st.metric(label=col_name, value=f"{val:.2e}")
+
+                st.caption("Raw Dataset")
+
+                # Format all numerical columns to scientific notation
+                column_config = {
+                    col: st.column_config.NumberColumn(format="%.4e")
+                    for col in item['data'].columns
+                }
+
+                st.dataframe(item['data'], use_container_width=True, column_config=column_config)
     else:
         st.info("👋 Welcome! Please upload your `residual.dat` files using the uploader above to get started.")
 


### PR DESCRIPTION
💡 **What:** Added a "Final Convergence" summary section using `st.metric` cards to display the last iteration's values directly above the raw data table. Also applied scientific notation formatting (`%.4e`) to all numerical columns in the `st.dataframe`.

🎯 **Why:** Presenting a massive, unformatted dataset (like OpenFOAM residuals) directly in a table is overwhelming. Users typically care most about the final convergence state and shouldn't be forced to scroll past thousands of rows to find it. Formatting the floating-point numbers consistently improves scannability and professional polish.

♿ **Accessibility:** The consistent formatting makes the large numerical data significantly easier to parse visually, reducing cognitive load. The metric cards pull critical information forward, saving users time and effort.

---
*PR created automatically by Jules for task [3858369962884361037](https://jules.google.com/task/3858369962884361037) started by @kastnerp*