### PR TITLE
🎨 Palette: [UX improvement] Wrap summary metrics to prevent truncation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -40,3 +40,7 @@
 ## 2026-03-14 - Data Summarization & Formatting in Tables
 **Learning:** Presenting a raw, massive dataset (like OpenFOAM residuals) directly in a table is overwhelming and unhelpful for the user's primary goal, which is usually assessing the final convergence state. Users are forced to scroll past thousands of rows to find the only information they care about. Additionally, raw floating-point numbers often display poorly without consistent formatting.
 **Action:** Always provide a high-level summary (e.g., using `st.metric` cards) of the most important data points (like the final iteration values) *above* the raw data table. Furthermore, use tools like `st.column_config` to enforce consistent, readable formatting (e.g., scientific notation `%.4e` for residuals) across the entire dataframe to improve scannability and professional polish.
+
+## 2024-03-24 - Responsive Grid Wrapping for Dynamic Content
+**Learning:** Generating dynamic horizontal columns (like `st.columns(len(data.columns))`) without a maximum width constraint creates severe layout problems when user data contains many items. In Streamlit, this causes text inside components like `st.metric` to become horizontally squished and truncated (e.g., "1.23..."), rendering the data unreadable.
+**Action:** Always implement explicit wrapping for dynamically generated grid layouts. Group items into chunks with a sane maximum (e.g., 4 columns per row) to ensure consistent readability regardless of how many variables the user provides.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -284,12 +284,19 @@ def main() -> None:
                 st.caption(f"Final Convergence (Iteration {item['data'].index[-1]})")
 
                 # Create a row of metrics for the last iteration
-                cols = st.columns(len(item['data'].columns))
+                # 🎨 Palette Improvement: Limit columns per row to prevent text truncation
+                # Wrapping dynamically generated columns ensures readability regardless of how many variables exist
+                max_cols_per_row = 4
+                num_vars = len(item['data'].columns)
                 last_row = item['data'].iloc[-1]
-                for col_idx, col_name in enumerate(item['data'].columns):
-                    with cols[col_idx]:
-                        val = last_row[col_name]
-                        st.metric(label=col_name, value=f"{val:.2e}")
+
+                for i in range(0, num_vars, max_cols_per_row):
+                    # Create a new row of columns, taking the remaining variables up to max_cols_per_row
+                    cols = st.columns(min(max_cols_per_row, num_vars - i))
+                    for j, col_name in enumerate(item['data'].columns[i:i + max_cols_per_row]):
+                        with cols[j]:
+                            val = last_row[col_name]
+                            st.metric(label=col_name, value=f"{val:.2e}")
 
                 st.caption("Raw Dataset")
 


### PR DESCRIPTION
💡 What: Modified the raw data tab summary metrics layout to chunk `st.columns` into groups of 4 per row.
🎯 Why: Datasets with many variables (e.g. 10 variables in k-omega SST models) were causing the single row of dynamically generated columns to become horizontally squished, truncating the metric text and rendering it unreadable.
📸 Before/After: Visual validation shows the metrics are nicely formatted and fully readable when chunked.
♿ Accessibility: Ensures text content remains readable and accessible.

---
*PR created automatically by Jules for task [12530669996698173336](https://jules.google.com/task/12530669996698173336) started by @kastnerp*