### PR TITLE
🎨 Palette: Contextualize final convergence metrics with baseline delta

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,3 +44,7 @@
 ## 2024-03-24 - Responsive Grid Wrapping for Dynamic Content
 **Learning:** Generating dynamic horizontal columns (like `st.columns(len(data.columns))`) without a maximum width constraint creates severe layout problems when user data contains many items. In Streamlit, this causes text inside components like `st.metric` to become horizontally squished and truncated (e.g., "1.23..."), rendering the data unreadable.
 **Action:** Always implement explicit wrapping for dynamically generated grid layouts. Group items into chunks with a sane maximum (e.g., 4 columns per row) to ensure consistent readability regardless of how many variables the user provides.
+
+## 2026-03-24 - Contextualizing Isolated Numbers via Baselines
+**Learning:** Displaying raw final values (e.g., in `st.metric`) lacks context for users trying to assess convergence progress, as they have to manually mentally compare the final value to their initial expectations.
+**Action:** Always provide context for isolated numbers by using features like `delta` in `st.metric` to explicitly show the relative change (e.g., order of magnitude drop) from a sensible baseline (like the first iteration). Add a `help` tooltip to ensure the baseline metric is clearly understood by the user.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -286,9 +286,11 @@ def main() -> None:
                 # Create a row of metrics for the last iteration
                 # 🎨 Palette Improvement: Limit columns per row to prevent text truncation
                 # Wrapping dynamically generated columns ensures readability regardless of how many variables exist
+                # Also adding delta to show convergence progress compared to the first iteration.
                 max_cols_per_row = 4
                 num_vars = len(item['data'].columns)
                 last_row = item['data'].iloc[-1]
+                first_row = item['data'].iloc[0]
 
                 for i in range(0, num_vars, max_cols_per_row):
                     # Create a new row of columns, taking the remaining variables up to max_cols_per_row
@@ -296,7 +298,19 @@ def main() -> None:
                     for j, col_name in enumerate(item['data'].columns[i:i + max_cols_per_row]):
                         with cols[j]:
                             val = last_row[col_name]
-                            st.metric(label=col_name, value=f"{val:.2e}")
+                            first_val = first_row[col_name]
+
+                            # Calculate the magnitude drop in log scale
+                            # Using max(val, 1e-20) to prevent log10(0) if residuals hit exactly 0
+                            mag_drop = np.log10(max(val, 1e-300)) - np.log10(max(first_val, 1e-300))
+
+                            st.metric(
+                                label=col_name,
+                                value=f"{val:.2e}",
+                                delta=f"{mag_drop:.1f} log",
+                                delta_color="inverse",
+                                help="Change in orders of magnitude since the first iteration."
+                            )
 
                 st.caption("Raw Dataset")
 


### PR DESCRIPTION
💡 **What:** Added a `delta` value (showing order of magnitude drop) and a `help` tooltip to the final convergence summary metrics (`st.metric`) in the Raw Data tab.
🎯 **Why:** Presenting the isolated final value requires the user to manually mentally estimate the total drop from their starting point to assess convergence quality. Showing the magnitude drop directly provides instant context.
📸 **Before/After:** The final convergence metrics now show a green (if dropping) sub-metric like "↓ -3.4 log" below the main scientific notation value.
♿ **Accessibility:** Added a `help` tooltip clarifying what the delta represents ("Change in orders of magnitude since the first iteration.").

---
*PR created automatically by Jules for task [6763688631574217662](https://jules.google.com/task/6763688631574217662) started by @kastnerp*