### PR TITLE
🎨 Palette: Add interactive legends to dense plots

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -215,6 +215,8 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
     ordered_cols = [c for c in FEATURE_COLUMNS if c in data.columns]
     ordered_cols.extend([c for c in data.columns if c not in ordered_cols])
 
+    selection = alt.selection_point(fields=["Variable"], bind="legend")
+
     chart = (
         alt.Chart(long_frame)
         .mark_line()
@@ -226,12 +228,14 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
                 scale=alt.Scale(type="log"),
             ),
             color=alt.Color("Variable:N", sort=ordered_cols),
+            opacity=alt.condition(selection, alt.value(1.0), alt.value(0.2)),
             tooltip=[
                 alt.Tooltip("Time:Q", format=".6g"),
                 alt.Tooltip("Variable:N"),
                 alt.Tooltip("Residual:Q", format=".6e"),
             ],
         )
+        .add_params(selection)
         .properties(height=height)
     )
 


### PR DESCRIPTION
💡 **What:** Added interactive legends to the main Altair residual plot in the `Interactive` tab. Users can now click on a variable in the legend to isolate its line, fading the other lines to 20% opacity.
🎯 **Why:** OpenFOAM residual plots often contain many intersecting lines (Ux, Uy, Uz, p, k, epsilon), making them difficult to read. As noted in the Palette journal (`2026-03-05 - Interactive Legends in Dense Plots`), interactive legends allow users to isolate specific variables dynamically without extra UI controls.
📸 **Before/After:** The legend now acts as an interactive selection tool instead of just a static color key.
♿ **Accessibility:** Reduces cognitive load and visual clutter by allowing users to focus on single traces of data without getting lost in overlapping lines.

---
*PR created automatically by Jules for task [7755681853785264289](https://jules.google.com/task/7755681853785264289) started by @kastnerp*