### PR TITLE
🎨 Palette: User-centric labeling for tabs and tooltips

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -230,9 +230,9 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
             color=alt.Color("Variable:N", sort=ordered_cols),
             opacity=alt.condition(selection, alt.value(1.0), alt.value(0.2)),
             tooltip=[
-                alt.Tooltip("Time:Q", format=".6g"),
-                alt.Tooltip("Variable:N"),
-                alt.Tooltip("Residual:Q", format=".6e"),
+                alt.Tooltip("Time:Q", title="Iteration", format=".6g"),
+                alt.Tooltip("Variable:N", title="Variable"),
+                alt.Tooltip("Residual:Q", title="Residual", format=".6e"),
             ],
         )
         .add_params(selection)
@@ -456,7 +456,7 @@ def main() -> None:
     interactive_height = controls[1].slider("Interactive height", 240, 900, 420, 20)
     static_height = controls[2].slider("Static height", 240, 900, 360, 20)
 
-    tab_interactive, tab_static, tab_table = st.tabs(["Interactive", "Static", "Data"])
+    tab_interactive, tab_static, tab_table = st.tabs(["Interactive Plot", "Static Plot", "Raw Data"])
 
     with tab_interactive:
         for item in parsed_items:


### PR DESCRIPTION
💡 **What:** 
- Updated `st.tabs` labels to use descriptive, functional language (`Interactive Plot`, `Static Plot`, `Raw Data`).
- Explicitly configured `alt.Tooltip` definitions to map raw dataframe column names to user-friendly titles (e.g., displaying "Iteration" instead of the raw column name "Time").

🎯 **Why:** 
Technical jargon or generic labels increase cognitive load. Users who upload files want to see plots or data, not abstract concepts like "Static" or "Interactive". Additionally, for OpenFOAM CFD data, users conceptualize the x-axis as "Iterations", whereas the internal dataframe uses the raw column name "Time". Translating this raw variable name into a user-centric label ("Iteration") in the tooltip significantly improves the clarity of the interactive chart.

📸 **Before/After:**
- **Tabs Before:** Interactive | Static | Data
- **Tabs After:** Interactive Plot | Static Plot | Raw Data
- **Tooltips Before:** Time: 100
- **Tooltips After:** Iteration: 100

♿ **Accessibility:**
Provides clearer, more descriptive textual context for screen readers navigating the tabs and tooltips, moving away from terse or technically driven labels.

---
*PR created automatically by Jules for task [10611729382353667520](https://jules.google.com/task/10611729382353667520) started by @kastnerp*