### PR TITLE
🎨 Palette: Add ephemeral success toast for file uploads

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -439,6 +439,14 @@ def main() -> None:
     err_count = len(errors)
     st.write(f"{len(uploaded_files)} files selected: {ok_count} parsed, {err_count} failed.")
 
+    if "processed_file_ids" not in st.session_state:
+        st.session_state.processed_file_ids = set()
+
+    new_file_ids = {str(item["file_id"]) for item in parsed_items} - st.session_state.processed_file_ids
+    if new_file_ids:
+        st.toast(f"🎉 Successfully processed {len(new_file_ids)} new file(s)!")
+        st.session_state.processed_file_ids.update(new_file_ids)
+
     for filename, message, tb in errors:
         st.error(f"{filename}: {message}")
         with st.expander("View error details"):


### PR DESCRIPTION
🎨 Palette: Add ephemeral success toast for file uploads

💡 **What:** Added an ephemeral success toast notification (`st.toast`) that appears when a user successfully uploads and parses new OpenFOAM residual files.
🎯 **Why:** To provide immediate, satisfying, and non-intrusive feedback confirming that the file was processed correctly without permanently cluttering the UI. The notification is correctly guarded by `st.session_state` to ensure it only triggers on *new* file uploads and doesn't fire repetitively when interacting with other UI controls (like sliders).
📸 **Before/After:** Before, the only feedback was a line of text changing. After, a small toast pops up in the corner with a celebration emoji.
♿ **Accessibility:** This provides clearer feedback on system state after a user action, improving overall usability.

---
*PR created automatically by Jules for task [16642457955297995688](https://jules.google.com/task/16642457955297995688) started by @kastnerp*