### PR TITLE
🎨 Palette: Add contextually relevant icons to download buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-03-24 - Enhancing Empty States and Error Messages
 **Learning:** Dead-end empty states and generic error messages provide poor user experiences. Users don't know what format to use for file uploads, and when errors occur, generic messages don't help them self-correct.
 **Action:** Always enhance empty states by showing explicit examples (e.g., using `st.code`) of expected file formats. For error notifications, always surface raw exception traces inside an `st.expander` to help users understand what went wrong without cluttering the main UI.
+
+## 2026-03-26 - Action Discoverability with Icons
+**Learning:** Text-only buttons for common primary actions (like downloading a CSV or exporting an image zip) blend into the UI, requiring users to read every button's text to find their desired action. This increases cognitive load and reduces discoverability.
+**Action:** Always pair prominent calls to action (like `st.download_button`) with contextually relevant, universally understood Material icons (e.g., `:material/download:` or `:material/folder_zip:`) to enhance scannability and create a more intuitive, accessible user experience.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -506,6 +506,7 @@ def main() -> None:
                 file_name=f"{Path(name).stem}.csv",
                 mime="text/csv",
                 key=f"interactive_csv_{file_id}",
+                icon=":material/download:",
             )
 
     with tab_static:
@@ -534,6 +535,7 @@ def main() -> None:
                 file_name=f"{Path(name).stem}.csv",
                 mime="text/csv",
                 key=f"static_csv_{file_id}",
+                icon=":material/download:",
             )
 
         if static_images:
@@ -543,6 +545,7 @@ def main() -> None:
                 file_name="openfoam_residual_static_plots.zip",
                 mime="application/zip",
                 key="export_all_static_images_zip",
+                icon=":material/folder_zip:",
             )
 
     with tab_table:
@@ -587,6 +590,7 @@ def main() -> None:
                 file_name=f"{Path(name).stem}.csv",
                 mime="text/csv",
                 key=f"table_csv_{file_id}",
+                icon=":material/download:",
             )
 
     with st.expander("FAQ: OpenFOAM Residual Plotting"):


### PR DESCRIPTION
💡 What: Added Material icons to all `st.download_button` calls across the interactive, static, and data tabs.
🎯 Why: Text-only buttons for primary actions can blend into the UI. Adding universally recognized icons (like a download arrow or zip folder) enhances scannability and reduces cognitive load, allowing users to find export actions more easily.
📸 Before/After: Standard Streamlit buttons without icons vs. buttons with `:material/download:` and `:material/folder_zip:` prefixes.
♿ Accessibility: Visual cues support text labels, making actions easier to identify for users scanning the interface quickly.

---
*PR created automatically by Jules for task [7169929673613779250](https://jules.google.com/task/7169929673613779250) started by @kastnerp*