### PR TITLE
🎨 Palette: Remove redundant numerical index from raw data table

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,7 @@
 ## 2026-03-26 - Action Discoverability with Icons
 **Learning:** Text-only buttons for common primary actions (like downloading a CSV or exporting an image zip) blend into the UI, requiring users to read every button's text to find their desired action. This increases cognitive load and reduces discoverability.
 **Action:** Always pair prominent calls to action (like `st.download_button`) with contextually relevant, universally understood Material icons (e.g., `:material/download:` or `:material/folder_zip:`) to enhance scannability and create a more intuitive, accessible user experience.
+
+## 2026-03-27 - Removing Redundant Table Indices
+**Learning:** When displaying Pandas DataFrames in Streamlit via `st.dataframe`, Streamlit automatically renders the dataframe's index as the first column. If the dataframe was previously reset (`data.reset_index()`), this results in a redundant, meaningless numerical column (0, 1, 2...) that clutters the UI and distracts from the actual user data.
+**Action:** Always use `hide_index=True` in `st.dataframe` when displaying dataframes that either lack a meaningful index or have had their meaningful index explicitly converted to a standard column, ensuring a clean and focused data presentation.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -581,6 +581,7 @@ def main() -> None:
                 width="stretch",
                 height=360,
                 column_config=col_config,
+                hide_index=True,
             )
             csv_buffer = io.StringIO()
             data.to_csv(csv_buffer)


### PR DESCRIPTION
💡 What: Added `hide_index=True` to the Streamlit dataframe component in the "Raw Data" tab.
🎯 Why: Because the underlying Pandas DataFrame uses `data.reset_index()` to convert the meaningful "Time" index into a standard column, Streamlit automatically prepends a redundant numerical index column (0, 1, 2...) to the table. This change hides that meaningless column, making the table cleaner and focusing the user's attention purely on the relevant convergence data.
♿ Accessibility: Reduces visual clutter and unnecessary cognitive load when scanning raw data tables.

Also added a corresponding learning entry to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [3349413854449990583](https://jules.google.com/task/3349413854449990583) started by @kastnerp*