### PR TITLE
🎨 Palette: Add unit formatting to height sliders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -60,3 +60,7 @@
 ## 2026-03-27 - Removing Redundant Table Indices
 **Learning:** When displaying Pandas DataFrames in Streamlit via `st.dataframe`, Streamlit automatically renders the dataframe's index as the first column. If the dataframe was previously reset (`data.reset_index()`), this results in a redundant, meaningless numerical column (0, 1, 2...) that clutters the UI and distracts from the actual user data.
 **Action:** Always use `hide_index=True` in `st.dataframe` when displaying dataframes that either lack a meaningful index or have had their meaningful index explicitly converted to a standard column, ensuring a clean and focused data presentation.
+
+## $(date +%Y-%m-%d) - Add unit formatting to Streamlit sliders
+**Learning:** Adding explicit units (e.g., `%d px`) directly to Streamlit `st.slider` widgets via the `format` parameter significantly improves clarity at a glance, reducing the need for users to read help tooltips to understand the unit of measurement.
+**Action:** When adding or updating Streamlit sliders that represent physical units (pixels, percentages, degrees), always use the `format` parameter to append the unit directly to the displayed value.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -418,11 +418,13 @@ def main() -> None:
         st.header("⚙️ Plot Settings")
         interactive_height = st.slider(
             "Interactive height", 240, 900, 420, 20,
+            format="%d px",
             disabled=not has_files,
             help="Adjust the vertical size (in pixels) of the interactive charts." if has_files else disabled_help
         )
         static_height = st.slider(
             "Static height", 240, 900, 360, 20,
+            format="%d px",
             disabled=not has_files,
             help="Adjust the vertical size (in pixels) of the static Matplotlib plots." if has_files else disabled_help
         )


### PR DESCRIPTION
**💡 What:** Added `format="%d px"` to the `interactive_height` and `static_height` sliders in the sidebar.
**🎯 Why:** This makes it immediately clear that the height unit is measured in pixels, eliminating ambiguity without requiring users to check the help tooltip.
**📸 Before/After:** The slider handles now explicitly say, for example, "420 px" instead of just "420".
**♿ Accessibility:** Reduces cognitive load by providing context immediately on the interactive element.

---
*PR created automatically by Jules for task [1177516584114219250](https://jules.google.com/task/1177516584114219250) started by @kastnerp*