### PR TITLE
🎨 Palette: Align data table column header with chart axis terminology

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,7 @@
 ## $(date +%Y-%m-%d) - Add unit formatting to Streamlit sliders
 **Learning:** Adding explicit units (e.g., `%d px`) directly to Streamlit `st.slider` widgets via the `format` parameter significantly improves clarity at a glance, reducing the need for users to read help tooltips to understand the unit of measurement.
 **Action:** When adding or updating Streamlit sliders that represent physical units (pixels, percentages, degrees), always use the `format` parameter to append the unit directly to the displayed value.
+
+## $(date +%Y-%m-%d) - Consistent Terminology Across UI Views
+**Learning:** When displaying the same underlying data attribute across different views (e.g., a chart's X-axis labeled 'Iterations' vs a data table's column labeled 'Time'), using inconsistent labels creates cognitive friction for the user trying to map the visual representation to the raw data.
+**Action:** Always ensure column headers in data tables (`st.column_config`) align perfectly with the axis titles used in corresponding charts to provide a cohesive, unified terminology across the entire application interface.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -578,6 +578,7 @@ def main() -> None:
                         )
 
             col_config = {c: st.column_config.NumberColumn(format="%.4e") for c in valid_cols}
+            col_config["Time"] = st.column_config.NumberColumn("Iterations", format="%g")
             st.dataframe(
                 data.reset_index(),
                 width="stretch",


### PR DESCRIPTION
💡 What: Reconfigured the data table's "Time" column header to display as "Iterations" with clear number formatting using `st.column_config`.

🎯 Why: The interactive and static plots label the X-axis as "Iterations". However, the raw data table labeled the exact same data points as "Time" using Streamlit's default number formatting. This terminology mismatch forces the user to mentally map "Iterations" on the chart to "Time" in the table. Using consistent terminology across the entire application interface reduces cognitive load and provides a more cohesive UX.

📸 Before/After: Visual changes were verified locally using Playwright. The table column header is now "Iterations", matching the plots.

♿ Accessibility: The explicit `%g` formatting also ensures that iteration counts don't get awkward decimal places or scientific notation when unnecessary.

---
*PR created automatically by Jules for task [18163950219511054068](https://jules.google.com/task/18163950219511054068) started by @kastnerp*