### PR TITLE
🎨 Palette: Add downloadable sample file to empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -68,3 +68,7 @@
 ## $(date +%Y-%m-%d) - Consistent Terminology Across UI Views
 **Learning:** When displaying the same underlying data attribute across different views (e.g., a chart's X-axis labeled 'Iterations' vs a data table's column labeled 'Time'), using inconsistent labels creates cognitive friction for the user trying to map the visual representation to the raw data.
 **Action:** Always ensure column headers in data tables (`st.column_config`) align perfectly with the axis titles used in corresponding charts to provide a cohesive, unified terminology across the entire application interface.
+
+## $(date +%Y-%m-%d) - Sample File Downloads in Empty States
+**Learning:** For file-upload dependent web applications, presenting an empty state without data acts as a hard barrier. Even if the expected format is documented, users must find or generate compatible files before they can evaluate the application's utility. Providing a downloadable sample file directly within the empty state significantly reduces this friction and improves onboarding.
+**Action:** Always include a clearly labeled, one-click `st.download_button` providing a minimal, valid sample file within empty states for upload-driven applications.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -438,6 +438,20 @@ def main() -> None:
     if not has_files:
         st.info("Upload one or more OpenFOAM residual files to start. Example `.dat` format:")
         st.code("# OpenFOAM\n# Time alpha beta gamma\n1 0.1 0.2 0.3\n2 0.01 0.02 0.03", language="text")
+
+        # Load sample data robustly using path relative to this script
+        sample_path = Path(__file__).parent / "test_residual.dat"
+        with open(sample_path, "rb") as f:
+            sample_data = f.read()
+
+        st.download_button(
+            label="Download sample file",
+            data=sample_data,
+            file_name="sample_residual.dat",
+            mime="text/plain",
+            icon=":material/download:",
+            help="Download a sample OpenFOAM residual file to test the application.",
+        )
         return
 
     parsed_items: list[dict[str, object]] = []


### PR DESCRIPTION
💡 **What:** Added a "Download sample file" button to the application's empty state that provides a ready-to-use `.dat` file. Appended an entry to `.Jules/palette.md` noting the importance of providing sample data for upload-driven applications.
🎯 **Why:** Presenting a "file upload required" empty state without providing any data acts as a friction point. Users must go find or generate an OpenFOAM residual file just to see if the tool is useful to them. Providing a sample file allows immediate testing and exploration, greatly reducing onboarding friction.
♿ **Accessibility:** Utilized Streamlit's native `st.download_button` which includes appropriate accessible markup by default, added a descriptive `help` tooltip, and included an intuitive Material icon (`:material/download:`).

---
*PR created automatically by Jules for task [461590685221515257](https://jules.google.com/task/461590685221515257) started by @kastnerp*