### PR TITLE
🎨 Palette: Add visual grouping and improve UI labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -72,3 +72,7 @@
 ## $(date +%Y-%m-%d) - Sample File Downloads in Empty States
 **Learning:** For file-upload dependent web applications, presenting an empty state without data acts as a hard barrier. Even if the expected format is documented, users must find or generate compatible files before they can evaluate the application's utility. Providing a downloadable sample file directly within the empty state significantly reduces this friction and improves onboarding.
 **Action:** Always include a clearly labeled, one-click `st.download_button` providing a minimal, valid sample file within empty states for upload-driven applications.
+
+## 2026-03-31 - Visual Grouping for Repeated Content Blocks
+**Learning:** When displaying complex repeated content blocks (like charts and data tables for multiple uploaded files) in a sequential layout, users can easily lose track of which block belongs to which file, leading to ambiguous action associations (e.g., clicking the wrong download button).
+**Action:** Always use clear visual separators (like `st.divider()`) between repeated complex UI blocks to create distinct boundaries and group related content together, significantly reducing cognitive load and preventing misclicks.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -405,7 +405,7 @@ def main() -> None:
     )
 
     uploaded_files = st.file_uploader(
-        "Select files",
+        "Upload OpenFOAM residual files",
         type=["dat", "log", "txt"],
         accept_multiple_files=True,
         help="Upload multiple .dat or .log files to compare convergence side-by-side.",
@@ -417,16 +417,16 @@ def main() -> None:
     with st.sidebar:
         st.header("⚙️ Plot Settings")
         interactive_height = st.slider(
-            "Interactive height", 240, 900, 420, 20,
+            "Interactive plot height", 240, 900, 420, 20,
             format="%d px",
             disabled=not has_files,
             help="Adjust the vertical size (in pixels) of the interactive charts." if has_files else disabled_help
         )
         static_height = st.slider(
-            "Static height", 240, 900, 360, 20,
+            "Static plot height", 240, 900, 360, 20,
             format="%d px",
             disabled=not has_files,
-            help="Adjust the vertical size (in pixels) of the static Matplotlib plots." if has_files else disabled_help
+            help="Adjust the vertical size (in pixels) of the static plots." if has_files else disabled_help
         )
         show_grid = st.checkbox(
             "Show static grid",
@@ -504,7 +504,7 @@ def main() -> None:
     tab_interactive, tab_static, tab_table = st.tabs(["Interactive Plot", "Static Plot", "Raw Data"])
 
     with tab_interactive:
-        for item in parsed_items:
+        for idx, item in enumerate(parsed_items):
             name = str(item["name"])
             file_id = str(item["file_id"])
             data = item["data"]
@@ -524,11 +524,13 @@ def main() -> None:
                 key=f"interactive_csv_{file_id}",
                 icon=":material/download:",
             )
+            if idx < len(parsed_items) - 1:
+                st.divider()
 
     with tab_static:
         static_images: list[tuple[str, bytes]] = []
 
-        for item in parsed_items:
+        for idx, item in enumerate(parsed_items):
             name = str(item["name"])
             file_id = str(item["file_id"])
             data = item["data"]
@@ -553,8 +555,12 @@ def main() -> None:
                 key=f"static_csv_{file_id}",
                 icon=":material/download:",
             )
+            if idx < len(parsed_items) - 1:
+                st.divider()
 
         if static_images:
+            if len(parsed_items) > 1:
+                st.divider()
             st.download_button(
                 "Export all static images (.zip)",
                 data=build_images_zip(static_images),
@@ -565,7 +571,7 @@ def main() -> None:
             )
 
     with tab_table:
-        for item in parsed_items:
+        for idx, item in enumerate(parsed_items):
             name = str(item["name"])
             file_id = str(item["file_id"])
             data = item["data"]
@@ -610,6 +616,8 @@ def main() -> None:
                 key=f"table_csv_{file_id}",
                 icon=":material/download:",
             )
+            if idx < len(parsed_items) - 1:
+                st.divider()
 
     with st.expander("FAQ: OpenFOAM Residual Plotting"):
         st.markdown(


### PR DESCRIPTION
🎨 Palette: Add visual grouping and improve UI labels

💡 What:
- Updated the file uploader label from "Select files" to "Upload OpenFOAM residual files".
- Updated plot height slider labels to use functional terminology ("Interactive plot height", "Static plot height").
- Added clear visual separators (`st.divider()`) between repeated content blocks (plots, tables) when comparing multiple files.
- Added a visual separator above the bulk "Export all static images" button.
- Documented the learning about visual grouping in `.Jules/palette.md`.

🎯 Why:
- Descriptive labels reduce cognitive load and remove technical jargon.
- Sequential displays of multiple files' results without distinct boundaries can cause ambiguous action associations (like clicking the wrong file's download button). Visual separators group related content tightly together, making the UI easier to parse.

📸 Before/After: (Screenshot uploaded to the PR verification process)
♿ Accessibility: Improves scannability and structural clarity for all users navigating complex result sets.

---
*PR created automatically by Jules for task [16022763122406219669](https://jules.google.com/task/16022763122406219669) started by @kastnerp*