### PR TITLE
🎨 Palette: Contextual Plot Image Download

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,7 @@
 ## 2026-03-31 - Visual Grouping for Repeated Content Blocks
 **Learning:** When displaying complex repeated content blocks (like charts and data tables for multiple uploaded files) in a sequential layout, users can easily lose track of which block belongs to which file, leading to ambiguous action associations (e.g., clicking the wrong download button).
 **Action:** Always use clear visual separators (like `st.divider()`) between repeated complex UI blocks to create distinct boundaries and group related content together, significantly reducing cognitive load and preventing misclicks.
+
+## 2024-04-01 - Contextual Export Actions
+**Learning:** When users see an image or visual chart, they expect the download button immediately beneath it to export that visual asset, not the raw underlying data. Redundant raw data downloads (especially if available elsewhere, like a Data tab) create a mismatch between user expectation and the button's action.
+**Action:** Always ensure export buttons are contextually relevant to the content immediately preceding them (e.g., placing an "Export Image" button below a chart, rather than a generic "Download CSV" button).

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -544,17 +544,17 @@ def main() -> None:
             if figure is None:
                 st.warning(f"{name}: no positive residual values to chart.")
             else:
-                static_images.append((name, figure_to_png_bytes(figure)))
+                png_bytes = figure_to_png_bytes(figure)
+                static_images.append((name, png_bytes))
                 st.pyplot(figure, clear_figure=True)
-            csv_bytes = data.to_csv().encode("utf-8")
-            st.download_button(
-                f"Download CSV ({name})",
-                data=csv_bytes,
-                file_name=f"{Path(name).stem}.csv",
-                mime="text/csv",
-                key=f"static_csv_{file_id}",
-                icon=":material/download:",
-            )
+                st.download_button(
+                    f"Download Plot Image ({name})",
+                    data=png_bytes,
+                    file_name=f"{Path(name).stem}.png",
+                    mime="image/png",
+                    key=f"static_png_{file_id}",
+                    icon=":material/image:",
+                )
             if idx < len(parsed_items) - 1:
                 st.divider()
 


### PR DESCRIPTION
Replaced the redundant "Download CSV" button under individual static Matplotlib plots with a "Download Plot Image" button (PNG). Added a relevant material image icon to the button. Users expect a download button beneath a plot image to download the image they are looking at, not the underlying raw data (which is already accessible via the "Raw Data" tab). This contextualizes the export action and reduces cognitive friction. Uses clear icons (`:material/image:`) and labels that specify the exact file extension (`.png`) and target filename (`{name}`).

---
*PR created automatically by Jules for task [5116348761460763237](https://jules.google.com/task/5116348761460763237) started by @kastnerp*