### PR TITLE
🎨 Palette: Add Material icons to application tabs for better scannability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -80,3 +80,6 @@
 ## 2024-04-01 - Contextual Export Actions
 **Learning:** When users see an image or visual chart, they expect the download button immediately beneath it to export that visual asset, not the raw underlying data. Redundant raw data downloads (especially if available elsewhere, like a Data tab) create a mismatch between user expectation and the button's action.
 **Action:** Always ensure export buttons are contextually relevant to the content immediately preceding them (e.g., placing an "Export Image" button below a chart, rather than a generic "Download CSV" button).
+## 2025-04-02 - Embellishing Streamlit Tabs
+**Learning:** Streamlit `st.tabs` does not currently support an `icon=` keyword argument, unlike other UI components.
+**Action:** When embellishing `st.tabs` for scannability, use the native `:material/icon_name:` syntax directly within the tab title string (e.g., `st.tabs([":material/show_chart: Tab 1", ":material/image: Tab 2"])`) to add small touches of visual delight.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -501,7 +501,7 @@ def main() -> None:
         help="Filenames are always shown when comparing multiple files." if show_names_default else "Show the filename above each plot.",
     )
 
-    tab_interactive, tab_static, tab_table = st.tabs(["Interactive Plot", "Static Plot", "Raw Data"])
+    tab_interactive, tab_static, tab_table = st.tabs([":material/show_chart: Interactive Plot", ":material/image: Static Plot", ":material/table_view: Raw Data"])
 
     with tab_interactive:
         for idx, item in enumerate(parsed_items):


### PR DESCRIPTION
This PR implements a small micro-UX improvement by adding Material Design icons to the main application tabs.

**💡 What:**
Added `:material/show_chart:`, `:material/image:`, and `:material/table_view:` icons to the titles of the Interactive Plot, Static Plot, and Raw Data tabs, respectively.

**🎯 Why:**
This small touch of visual delight makes the application interface more intuitive to navigate. It improves scannability, allowing users to quickly identify the purpose of a tab without reading the full text.

**📸 Before/After:**
*(See visual verification screenshot showing the updated tab icons)*

**♿ Accessibility:**
The icons are purely decorative and visually reinforce the text labels. Since they are part of the label string and not standalone images, they don't interfere with existing text-based navigation.

---
*PR created automatically by Jules for task [10843955884290994575](https://jules.google.com/task/10843955884290994575) started by @kastnerp*