### PR TITLE
🎨 Palette: Align download buttons with visual context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -83,3 +83,7 @@
 ## 2025-04-02 - Embellishing Streamlit Tabs
 **Learning:** Streamlit `st.tabs` does not currently support an `icon=` keyword argument, unlike other UI components.
 **Action:** When embellishing `st.tabs` for scannability, use the native `:material/icon_name:` syntax directly within the tab title string (e.g., `st.tabs([":material/show_chart: Tab 1", ":material/image: Tab 2"])`) to add small touches of visual delight.
+
+## 2024-04-04 - Aligning download actions with visual context
+**Learning:** Download buttons placed directly beneath visual charts create an expectation of downloading an image. Placing raw data (CSV) downloads in these locations causes a mismatch between user expectation and the button's action.
+**Action:** Remove raw data download buttons from beneath visual charts. Ensure that download buttons beneath charts only export images, and that raw data downloads are placed in a dedicated "Raw Data" or similar tab. Add descriptive `help` tooltips to clarify the specific action of each download button.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -515,15 +515,6 @@ def main() -> None:
                 st.warning(f"{name}: no positive residual values to chart.")
             else:
                 st.altair_chart(chart, width="stretch")
-            csv_bytes = data.to_csv().encode("utf-8")
-            st.download_button(
-                f"Download CSV ({name})",
-                data=csv_bytes,
-                file_name=f"{Path(name).stem}.csv",
-                mime="text/csv",
-                key=f"interactive_csv_{file_id}",
-                icon=":material/download:",
-            )
             if idx < len(parsed_items) - 1:
                 st.divider()
 
@@ -554,6 +545,7 @@ def main() -> None:
                     mime="image/png",
                     key=f"static_png_{file_id}",
                     icon=":material/image:",
+                    help="Download this static plot as a PNG image.",
                 )
             if idx < len(parsed_items) - 1:
                 st.divider()
@@ -568,6 +560,7 @@ def main() -> None:
                 mime="application/zip",
                 key="export_all_static_images_zip",
                 icon=":material/folder_zip:",
+                help="Download all static plot images as a single ZIP archive.",
             )
 
     with tab_table:
@@ -615,6 +608,7 @@ def main() -> None:
                 mime="text/csv",
                 key=f"table_csv_{file_id}",
                 icon=":material/download:",
+                help="Download the raw residual data as a CSV file.",
             )
             if idx < len(parsed_items) - 1:
                 st.divider()


### PR DESCRIPTION
🎨 **Palette: Align download actions with visual context**

**What was done:**
1.  **Removed misplaced button**: Eliminated the redundant "Download CSV" button from the bottom of the "Interactive Plot" tab in `streamlit_app.py`.
2.  **Added tooltips**: Integrated descriptive `help` tooltips into all remaining `st.download_button` widgets across the "Static Plot" and "Raw Data" tabs.
3.  **Journaled learning**: Documented the UX insight regarding contextual export actions in the `.Jules/palette.md` journal.

**Why it matters:**
Placing raw data download buttons immediately beneath visual charts creates a frustrating mismatch between user expectation (downloading the visible chart) and the button's actual action (downloading CSV text). By restricting raw data downloads to the "Raw Data" tab and adding clear tooltips, we reduce cognitive load, prevent erroneous clicks, and ensure the UI behaves predictably. The added tooltips also enhance accessibility for screen readers and power users.

**Testing:**
*   Visually verified via a custom Playwright test suite.
*   Confirmed the removal of the CSV button from the interactive view.
*   Confirmed the tooltips render successfully on hover for both image and data exports.

---
*PR created automatically by Jules for task [8391970234859236570](https://jules.google.com/task/8391970234859236570) started by @kastnerp*