### PR TITLE
🎨 Palette: Add instant demo data loading to empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -61,15 +61,15 @@
 **Learning:** When displaying Pandas DataFrames in Streamlit via `st.dataframe`, Streamlit automatically renders the dataframe's index as the first column. If the dataframe was previously reset (`data.reset_index()`), this results in a redundant, meaningless numerical column (0, 1, 2...) that clutters the UI and distracts from the actual user data.
 **Action:** Always use `hide_index=True` in `st.dataframe` when displaying dataframes that either lack a meaningful index or have had their meaningful index explicitly converted to a standard column, ensuring a clean and focused data presentation.
 
-## $(date +%Y-%m-%d) - Add unit formatting to Streamlit sliders
+## 2026-04-04 - Add unit formatting to Streamlit sliders
 **Learning:** Adding explicit units (e.g., `%d px`) directly to Streamlit `st.slider` widgets via the `format` parameter significantly improves clarity at a glance, reducing the need for users to read help tooltips to understand the unit of measurement.
 **Action:** When adding or updating Streamlit sliders that represent physical units (pixels, percentages, degrees), always use the `format` parameter to append the unit directly to the displayed value.
 
-## $(date +%Y-%m-%d) - Consistent Terminology Across UI Views
+## 2026-04-04 - Consistent Terminology Across UI Views
 **Learning:** When displaying the same underlying data attribute across different views (e.g., a chart's X-axis labeled 'Iterations' vs a data table's column labeled 'Time'), using inconsistent labels creates cognitive friction for the user trying to map the visual representation to the raw data.
 **Action:** Always ensure column headers in data tables (`st.column_config`) align perfectly with the axis titles used in corresponding charts to provide a cohesive, unified terminology across the entire application interface.
 
-## $(date +%Y-%m-%d) - Sample File Downloads in Empty States
+## 2026-04-04 - Sample File Downloads in Empty States
 **Learning:** For file-upload dependent web applications, presenting an empty state without data acts as a hard barrier. Even if the expected format is documented, users must find or generate compatible files before they can evaluate the application's utility. Providing a downloadable sample file directly within the empty state significantly reduces this friction and improves onboarding.
 **Action:** Always include a clearly labeled, one-click `st.download_button` providing a minimal, valid sample file within empty states for upload-driven applications.
 
@@ -87,3 +87,7 @@
 ## 2024-04-04 - Aligning download actions with visual context
 **Learning:** Download buttons placed directly beneath visual charts create an expectation of downloading an image. Placing raw data (CSV) downloads in these locations causes a mismatch between user expectation and the button's action.
 **Action:** Remove raw data download buttons from beneath visual charts. Ensure that download buttons beneath charts only export images, and that raw data downloads are placed in a dedicated "Raw Data" or similar tab. Add descriptive `help` tooltips to clarify the specific action of each download button.
+
+## 2026-04-04 - Demo Buttons in Empty States
+**Learning:** For file-upload dependent web applications, providing a sample file download in the empty state is helpful, but still requires the user to manually upload it. Adding an explicit "Load sample data" button that automatically populates the application with sample data removes all friction and instantly demonstrates the application's value proposition without making the user leave the page.
+**Action:** In addition to providing sample file downloads, always add a primary "Load sample data" (or "Load Demo Data") button in the empty states of upload-driven applications. Manage this via `st.session_state` so the demo data is instantly cleared once a real file is uploaded, and provide a clear way for the user to manually exit the demo view.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -411,7 +411,13 @@ def main() -> None:
         help="Upload multiple .dat or .log files to compare convergence side-by-side.",
     )
 
-    has_files = bool(uploaded_files)
+    if "use_sample_data" not in st.session_state:
+        st.session_state.use_sample_data = False
+
+    if uploaded_files:
+        st.session_state.use_sample_data = False
+
+    has_files = bool(uploaded_files) or st.session_state.use_sample_data
     disabled_help = "⚠️ Please upload a residual file first to enable this setting."
 
     with st.sidebar:
@@ -444,21 +450,47 @@ def main() -> None:
         with open(sample_path, "rb") as f:
             sample_data = f.read()
 
-        st.download_button(
-            label="Download sample file",
-            data=sample_data,
-            file_name="sample_residual.dat",
-            mime="text/plain",
-            icon=":material/download:",
-            help="Download a sample OpenFOAM residual file to test the application.",
-        )
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button("Load sample data", icon=":material/play_circle:", help="Instantly load sample data to see how the app works."):
+                st.session_state.use_sample_data = True
+                st.rerun()
+        with col2:
+            st.download_button(
+                label="Download sample file",
+                data=sample_data,
+                file_name="sample_residual.dat",
+                mime="text/plain",
+                icon=":material/download:",
+                help="Download a sample OpenFOAM residual file to test the application.",
+            )
         return
+
+    if st.session_state.use_sample_data and not uploaded_files:
+        class DummyFile:
+            def __init__(self, name: str, data: bytes):
+                self.name = name
+                self._data = data
+            def getvalue(self) -> bytes:
+                return self._data
+
+        sample_path = Path(__file__).parent / "test_residual.dat"
+        with open(sample_path, "rb") as f:
+            sample_data = f.read()
+        files_to_process = [DummyFile("test_residual.dat", sample_data)]
+
+        st.info("Currently viewing sample data.")
+        if st.button("Clear sample data", icon=":material/close:", help="Clear the sample data to upload your own files."):
+            st.session_state.use_sample_data = False
+            st.rerun()
+    else:
+        files_to_process = uploaded_files
 
     parsed_items: list[dict[str, object]] = []
     errors: list[tuple[str, str, str]] = []
 
-    with st.spinner("Processing uploaded files..."):
-        for uploaded in uploaded_files:
+    with st.spinner("Processing files..."):
+        for uploaded in files_to_process:
             raw_bytes = uploaded.getvalue()
             text = raw_bytes.decode("utf-8", errors="replace")
             try:
@@ -475,7 +507,7 @@ def main() -> None:
 
     ok_count = len(parsed_items)
     err_count = len(errors)
-    st.write(f"{len(uploaded_files)} files selected: {ok_count} parsed, {err_count} failed.")
+    st.write(f"{len(files_to_process)} files selected: {ok_count} parsed, {err_count} failed.")
 
     if "processed_file_ids" not in st.session_state:
         st.session_state.processed_file_ids = set()


### PR DESCRIPTION
💡 What: Added a "Load sample data" button to the empty state, allowing users to instantly populate the application with a dummy `.dat` file.
🎯 Why: Providing a sample file to download is helpful, but still requires the user to manually upload it. This new UX pattern removes all friction, instantly demonstrating the application's value proposition without making the user leave the page.
📸 Before/After: Verified via Playwright. The empty state now has a primary action button that seamlessly transitions the app into a fully populated state.
♿ Accessibility: Used descriptive help text for the new buttons and standard Material icons (`play_circle` and `close`) to improve scannability.

---
*PR created automatically by Jules for task [12326145374574377909](https://jules.google.com/task/12326145374574377909) started by @kastnerp*