### PR TITLE
🎨 Palette: Add hover interaction to Altair line chart

### DIFF
--- a/streamlit.log
+++ b/streamlit.log
@@ -1,0 +1,9 @@
+
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
+
+
+  You can now view your Streamlit app in your browser.
+
+  Local URL: http://localhost:8501
+  Network URL: http://192.168.0.2:8501
+  External URL: http://35.224.132.190:8501

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -216,6 +216,12 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
     ordered_cols.extend([c for c in data.columns if c not in ordered_cols])
 
     selection = alt.selection_point(fields=["Variable"], bind="legend")
+    hover = alt.selection_point(
+        fields=["Variable"],
+        on="pointerover",
+        empty=False,
+        clear="pointerout"
+    )
 
     chart = (
         alt.Chart(long_frame)
@@ -229,13 +235,14 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
             ),
             color=alt.Color("Variable:N", sort=ordered_cols),
             opacity=alt.condition(selection, alt.value(1.0), alt.value(0.2)),
+            strokeWidth=alt.condition(hover, alt.value(3), alt.value(1.5)),
             tooltip=[
                 alt.Tooltip("Time:Q", title="Iteration", format=".6g"),
                 alt.Tooltip("Variable:N", title="Variable"),
                 alt.Tooltip("Residual:Q", title="Residual", format=".6e"),
             ],
         )
-        .add_params(selection)
+        .add_params(selection, hover)
         .properties(height=height)
     )
 


### PR DESCRIPTION
🎨 **Palette: Altair Chart Hover Interaction**

💡 **What:**
Added a hover interaction to the main interactive Altair chart. When the cursor points over a specific line, its stroke width smoothly increases to visually highlight it.

🎯 **Why:**
OpenFOAM residual plots often contain multiple overlapping lines representing different variables (Ux, Uy, p, etc.) that decay at similar rates. While the legend selection helps isolate lines, tracing a specific line within the full context of the chart was difficult. This hover interaction provides immediate, intuitive visual feedback without requiring the user to click back and forth on the legend.

♿ **Accessibility:**
Improves visual clarity and cognitive accessibility by making complex, dense data easier to parse and interact with.

*Note: Verified visually using a Playwright script.*

---
*PR created automatically by Jules for task [11196156287633931844](https://jules.google.com/task/11196156287633931844) started by @kastnerp*