### PR TITLE
🎨 Palette: Consolidate global layout controls into sidebar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -98,3 +98,7 @@
 ## 2026-04-06 - Empty State Button Styling
 **Learning:** In empty states containing multiple side-by-side buttons (e.g., "Load demo data" vs. "Download sample file" in columns), using default Streamlit button styling causes the buttons to have different widths depending on their text, looking messy. Furthermore, lacking a visual hierarchy makes it unclear which action is preferred.
 **Action:** Always add `type="primary"` to the most frictionless onboarding action to guide the user. Additionally, set `use_container_width=True` on all buttons in empty-state row layouts so they align uniformly and provide larger, more accessible click targets.
+
+## 2026-04-06 - Grouping Global Controls
+**Learning:** Placing layout toggles (like "Show filenames") directly inside the main content area creates visual fragmentation and dynamically pushes the main tabbed content down when they appear. This disrupts the reading flow and separates related controls.
+**Action:** Always group global display controls logically within dedicated sections (like `st.sidebar` under a "Settings" header). Use tools like `st.empty()` placeholders to inject controls into these sections even if they depend on data loaded later in the main script.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -429,6 +429,7 @@ def main() -> None:
 
     with st.sidebar:
         st.header("⚙️ Plot Settings")
+        filenames_placeholder = st.empty()
         interactive_height = st.slider(
             "Interactive plot height", 240, 900, 420, 20,
             format="%d px",
@@ -521,14 +522,13 @@ def main() -> None:
 
     ok_count = len(parsed_items)
     err_count = len(errors)
-    st.write(f"{len(files_to_process)} files selected: {ok_count} parsed, {err_count} failed.")
 
     if "processed_file_ids" not in st.session_state:
         st.session_state.processed_file_ids = set()
 
     new_file_ids = {str(item["file_id"]) for item in parsed_items} - st.session_state.processed_file_ids
     if new_file_ids:
-        st.toast(f"🎉 Successfully processed {len(new_file_ids)} new file(s)!")
+        st.toast(f"Successfully processed {len(new_file_ids)} new file(s)!", icon="🎉")
         st.session_state.processed_file_ids.update(new_file_ids)
 
     for filename, message, tb in errors:
@@ -540,12 +540,13 @@ def main() -> None:
         return
 
     show_names_default = len(parsed_items) > 1
-    show_filenames = st.checkbox(
-        "Show filenames",
-        value=show_names_default,
-        disabled=show_names_default,
-        help="Filenames are always shown when comparing multiple files." if show_names_default else "Show the filename above each plot.",
-    )
+    with filenames_placeholder:
+        show_filenames = st.checkbox(
+            "Show filenames",
+            value=show_names_default,
+            disabled=show_names_default,
+            help="Filenames are always shown when comparing multiple files." if show_names_default else "Show the filename above each plot.",
+        )
 
     tab_interactive, tab_static, tab_table = st.tabs([":material/show_chart: Interactive Plot", ":material/image: Static Plot", ":material/table_view: Raw Data"])
 


### PR DESCRIPTION
💡 What: Consolidates the global "Show filenames" control into the sidebar, removes redundant status text, and properly aligns the success toast emoji using the native icon parameter.
🎯 Why: Grouping global toggles logically in a "Settings" sidebar reduces cognitive load and prevents the main tabbed interface from shifting downwards when the toggle dynamically appears. 
📸 Before/After: Visual changes verified via Playwright, confirming clean UI arrangement in the sidebar and visually distinct success notification.

---
*PR created automatically by Jules for task [3223248915453465750](https://jules.google.com/task/3223248915453465750) started by @kastnerp*