### PR TITLE
🎨 Palette: Conditional Batch Data Export

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -102,3 +102,7 @@
 ## 2026-04-06 - Grouping Global Controls
 **Learning:** Placing layout toggles (like "Show filenames") directly inside the main content area creates visual fragmentation and dynamically pushes the main tabbed content down when they appear. This disrupts the reading flow and separates related controls.
 **Action:** Always group global display controls logically within dedicated sections (like `st.sidebar` under a "Settings" header). Use tools like `st.empty()` placeholders to inject controls into these sections even if they depend on data loaded later in the main script.
+
+## 2024-04-06 - Conditional Batch Actions for Redundancy Reduction
+**Learning:** Batch actions like "Export all as zip" are extremely useful for users working with multiple files, saving them repetitive clicks. However, rendering a batch "Export all" button when only one file is present in the view is redundant and confusing, creating a mismatch between UI options and actual data state.
+**Action:** Always wrap batch actions (like zipping multiple images or CSVs) in a conditional check (e.g., `if len(items) > 1:`) so they only render when they provide actual value, keeping the UI clean and relevant. Additionally, ensure these batch actions are available consistently across all applicable tabs (e.g., both static images and raw data tables) to provide a cohesive experience.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -294,17 +294,17 @@ def sanitize_stem(name: str) -> str:
     return stem or "plot"
 
 
-def build_images_zip(images: list[tuple[str, bytes]]) -> bytes:
+def build_zip(items: list[tuple[str, bytes]], suffix_name: str, ext: str) -> bytes:
     buffer = io.BytesIO()
     used_names: dict[str, int] = {}
 
     with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for original_name, image_bytes in images:
-            base_name = f"{sanitize_stem(original_name)}_static"
+        for original_name, file_bytes in items:
+            base_name = f"{sanitize_stem(original_name)}_{suffix_name}"
             index = used_names.get(base_name, 0)
             used_names[base_name] = index + 1
             suffix = f"_{index + 1}" if index else ""
-            archive.writestr(f"{base_name}{suffix}.png", image_bytes)
+            archive.writestr(f"{base_name}{suffix}.{ext}", file_bytes)
 
     return buffer.getvalue()
 
@@ -597,12 +597,11 @@ def main() -> None:
             if idx < len(parsed_items) - 1:
                 st.divider()
 
-        if static_images:
-            if len(parsed_items) > 1:
-                st.divider()
+        if len(static_images) > 1:
+            st.divider()
             st.download_button(
                 "Export all static images (.zip)",
-                data=build_images_zip(static_images),
+                data=build_zip(static_images, "static", "png"),
                 file_name="openfoam_residual_static_plots.zip",
                 mime="application/zip",
                 key="export_all_static_images_zip",
@@ -611,6 +610,7 @@ def main() -> None:
             )
 
     with tab_table:
+        all_csvs: list[tuple[str, bytes]] = []
         for idx, item in enumerate(parsed_items):
             name = str(item["name"])
             file_id = str(item["file_id"])
@@ -648,9 +648,11 @@ def main() -> None:
             )
             csv_buffer = io.StringIO()
             data.to_csv(csv_buffer)
+            csv_bytes = csv_buffer.getvalue().encode("utf-8")
+            all_csvs.append((name, csv_bytes))
             st.download_button(
                 f"Download CSV ({name})",
-                data=csv_buffer.getvalue().encode("utf-8"),
+                data=csv_bytes,
                 file_name=f"{Path(name).stem}.csv",
                 mime="text/csv",
                 key=f"table_csv_{file_id}",
@@ -659,6 +661,18 @@ def main() -> None:
             )
             if idx < len(parsed_items) - 1:
                 st.divider()
+
+        if len(all_csvs) > 1:
+            st.divider()
+            st.download_button(
+                "Export all data (.zip)",
+                data=build_zip(all_csvs, "data", "csv"),
+                file_name="openfoam_residual_data.zip",
+                mime="application/zip",
+                key="export_all_data_zip",
+                icon=":material/folder_zip:",
+                help="Download all raw residual data as a single ZIP archive.",
+            )
 
     with st.expander("FAQ: OpenFOAM Residual Plotting", icon=":material/help:"):
         st.markdown(


### PR DESCRIPTION
This PR introduces a micro-UX improvement by making batch export actions conditional and consistent. 

- Refactors `build_images_zip` to a generic `build_zip` to support multiple extensions.
- Wraps the "Export all static images (.zip)" button in `if len(static_images) > 1:` to avoid redundancy.
- Adds an equivalent "Export all data (.zip)" button to the raw data tab when multiple CSVs are generated, saving users from repetitive clicks.
- Updates `.Jules/palette.md` with the new learning regarding conditional batch actions.

---
*PR created automatically by Jules for task [8333915317311556055](https://jules.google.com/task/8333915317311556055) started by @kastnerp*