### PR TITLE
🎨 Palette: Add ARIA description to Altair chart for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -106,3 +106,7 @@
 ## 2024-04-06 - Conditional Batch Actions for Redundancy Reduction
 **Learning:** Batch actions like "Export all as zip" are extremely useful for users working with multiple files, saving them repetitive clicks. However, rendering a batch "Export all" button when only one file is present in the view is redundant and confusing, creating a mismatch between UI options and actual data state.
 **Action:** Always wrap batch actions (like zipping multiple images or CSVs) in a conditional check (e.g., `if len(items) > 1:`) so they only render when they provide actual value, keeping the UI clean and relevant. Additionally, ensure these batch actions are available consistently across all applicable tabs (e.g., both static images and raw data tables) to provide a cohesive experience.
+
+## 2026-04-06 - Accessible Data Visualizations
+**Learning:** Data visualizations like Altair/Vega-Lite charts are inherently opaque to screen readers by default. Without an explicit description, visually impaired users cannot understand what the chart represents or what data it contains.
+**Action:** Always provide a clear, descriptive `aria-label` equivalent for charts. In Altair, use `.properties(description="...")` to inject a dynamic description string that explains the chart's purpose and the data it visualizes.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -243,7 +243,10 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
             ],
         )
         .add_params(selection, hover)
-        .properties(height=height)
+        .properties(
+            height=height,
+            description=f"Interactive line chart showing OpenFOAM residual convergence over iterations for variables: {', '.join(ordered_cols)}. Use the legend to isolate specific variables."
+        )
     )
 
     if interactive:


### PR DESCRIPTION
**💡 What:** Added a dynamic `description` property to the interactive Altair line chart, generating an `aria-label` attribute on the rendered output.

**🎯 Why:** Data visualizations rendered via `<canvas>` or SVGs are inherently opaque to screen readers by default. By explicitly providing a description (including which variables are being plotted), visually impaired users can now understand what the chart represents and interacts with it using the legend. 

**♿ Accessibility:** Improves screen reader accessibility by providing an explicit description of the visual element's purpose and contents.

---
*PR created automatically by Jules for task [5416714692768681023](https://jules.google.com/task/5416714692768681023) started by @kastnerp*