### PR TITLE
🎨 Palette: Comprehensive empty state format examples

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -110,3 +110,7 @@
 ## 2026-04-06 - Accessible Data Visualizations
 **Learning:** Data visualizations like Altair/Vega-Lite charts are inherently opaque to screen readers by default. Without an explicit description, visually impaired users cannot understand what the chart represents or what data it contains.
 **Action:** Always provide a clear, descriptive `aria-label` equivalent for charts. In Altair, use `.properties(description="...")` to inject a dynamic description string that explains the chart's purpose and the data it visualizes.
+
+## 2026-04-13 - Comprehensive Empty State Examples
+**Learning:** When an application supports multiple distinct file formats, showing an example for only one format leaves users guessing about the others. Providing a massive text block with examples for all formats is cluttered.
+**Action:** When a Streamlit application accepts multiple file formats, enhance the empty state by using `st.tabs` to neatly organize and present explicit format examples (e.g., via `st.code`) for each supported type, ensuring comprehensive guidance without UI clutter.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -453,8 +453,12 @@ def main() -> None:
         )
 
     if not has_files:
-        st.info("Upload one or more OpenFOAM residual files to start. Example `.dat` format:", icon=":material/upload_file:")
-        st.code("# OpenFOAM\n# Time alpha beta gamma\n1 0.1 0.2 0.3\n2 0.01 0.02 0.03", language="text")
+        st.info("Upload one or more OpenFOAM residual files to start. Supported formats:", icon=":material/upload_file:")
+        tab_dat, tab_log = st.tabs([":material/description: .dat Example", ":material/article: .log Example"])
+        with tab_dat:
+            st.code("# OpenFOAM\n# Time alpha beta gamma\n1 0.1 0.2 0.3\n2 0.01 0.02 0.03", language="text")
+        with tab_log:
+            st.code("Time = 1\nSolving for Ux, Initial residual = 0.1, Final residual = 0.01, No Iterations 10\nSolving for Uy, Initial residual = 0.2, Final residual = 0.02, No Iterations 10", language="text")
 
         # Load sample data robustly using path relative to this script
         sample_path = Path(__file__).parent / "test_residual.dat"


### PR DESCRIPTION
💡 What: Updated the initial empty state to display format examples for both supported file types (`.dat` and `.log`) using clean, organized tabs instead of just showing the `.dat` format.
🎯 Why: The application supports both `.dat` and `.log` OpenFOAM residual files, which have completely different internal structures. Users uploading `.log` files were previously left without guidance on the expected format, causing confusion. Using tabs (`st.tabs`) allows us to provide comprehensive guidance without cluttering the UI.
♿ Accessibility: N/A (General UX improvement for guidance)

---
*PR created automatically by Jules for task [4813331116610644480](https://jules.google.com/task/4813331116610644480) started by @kastnerp*