### PR TITLE
🎨 Palette: Add discoverability hint to interactive chart legend

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -118,3 +118,6 @@
 ## 2026-04-13 - Comprehensive Empty State Examples
 **Learning:** When an application supports multiple distinct file formats, showing an example for only one format leaves users guessing about the others. Providing a massive text block with examples for all formats is cluttered.
 **Action:** When a Streamlit application accepts multiple file formats, enhance the empty state by using `st.tabs` to neatly organize and present explicit format examples (e.g., via `st.code`) for each supported type, ensuring comprehensive guidance without UI clutter.
+## 2024-05-14 - Altair Interactive Legend Discoverability
+**Learning:** Altair line charts with `bind="legend"` selections offer powerful interactivity (isolating lines), but this functionality is completely invisible to users by default. Without a visual cue, users rarely discover they can click the legend.
+**Action:** Always append a brief, actionable hint (e.g., `legend=alt.Legend(title="Variable (click to isolate)")`) to the legend title when binding selections to it in Altair/Streamlit.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -233,7 +233,11 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
                 title="Residuals",
                 scale=alt.Scale(type="log"),
             ),
-            color=alt.Color("Variable:N", sort=ordered_cols),
+            color=alt.Color(
+                "Variable:N",
+                sort=ordered_cols,
+                legend=alt.Legend(title="Variable (click to isolate)")
+            ),
             opacity=alt.condition(selection, alt.value(1.0), alt.value(0.2)),
             strokeWidth=alt.condition(hover, alt.value(3), alt.value(1.5)),
             tooltip=[


### PR DESCRIPTION
💡 **What**: Appended `(click to isolate)` to the Altair chart legend title.
🎯 **Why**: The legend in the interactive plot tab is bound to a selection (`bind="legend"`), allowing users to click variables to isolate their respective lines. However, this powerful capability lacks default visual affordance. By providing an explicit, actionable hint, users can easily discover and utilize this feature.
📸 **Before/After**: The legend title changed from `Variable` to `Variable (click to isolate)`.
♿ **Accessibility**: Improves general usability by explicitly documenting interactive features directly in the UI instead of relying on hidden states or external documentation.

---
*PR created automatically by Jules for task [7393803190590033400](https://jules.google.com/task/7393803190590033400) started by @kastnerp*