### PR TITLE
🎨 Palette: Add context to metrics with sparklines

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -121,3 +121,7 @@
 ## 2024-05-14 - Altair Interactive Legend Discoverability
 **Learning:** Altair line charts with `bind="legend"` selections offer powerful interactivity (isolating lines), but this functionality is completely invisible to users by default. Without a visual cue, users rarely discover they can click the legend.
 **Action:** Always append a brief, actionable hint (e.g., `legend=alt.Legend(title="Variable (click to isolate)")`) to the legend title when binding selections to it in Altair/Streamlit.
+
+## 2026-04-15 - Enhancing single-value metrics with sparklines and borders
+**Learning:** Displaying standalone final values (e.g., using `st.metric`) is useful, but often lacks visual context regarding how the value was reached. While the `delta` parameter shows the total change, adding a sparkline via `chart_data` (especially with log-scaled values for data that changes by orders of magnitude) provides an immediate, intuitive visual history of the data's progression without requiring a full chart. Furthermore, applying `border=True` neatly bounds the metric and its accompanying sparkline, establishing a clear visual hierarchy and preventing the UI from looking disorganized.
+**Action:** Always consider adding `chart_data` to `st.metric` when visualizing single values derived from time-series or sequential data to provide inline visual context. Ensure the data passed to `chart_data` is appropriately scaled (e.g., log10 for exponential decay) so the sparkline is informative, and use `border=True` to neatly containerize the component.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import math
 import traceback
 import re
 import zipfile
@@ -639,12 +640,18 @@ def main() -> None:
                     first_val = float(clean_series.iloc[0])
                     final_val = float(clean_series.iloc[-1])
                     diff = final_val - first_val
+
+                    sparkline_data = [math.log10(v) if v > 0 else 0 for v in clean_series.tolist()]
+                    sparkline_data = sparkline_data[::max(1, len(sparkline_data) // 100)]
+
                     with cols[j]:
                         st.metric(
                             label=col,
-                            value=f"{final_val:.4e}",
+                            value=f"{final_val:.2e}",
                             delta=f"{diff:.2e}",
                             delta_color="inverse",
+                            border=True,
+                            chart_data=sparkline_data,
                             help=f"Change from initial iteration ({first_val:.4e})",
                         )
 


### PR DESCRIPTION
Adds a visual sparkline (log-scaled) and a border to the `st.metric` elements in the summary table to improve context, and fixes text truncation issues.

---
*PR created automatically by Jules for task [17596404992509267565](https://jules.google.com/task/17596404992509267565) started by @kastnerp*