### PR TITLE
🎨 Palette: Use semantic headers in FAQ section

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -695,13 +695,13 @@ def main() -> None:
     with st.expander("FAQ: OpenFOAM Residual Plotting", icon=":material/help:"):
         st.markdown(
             """
-            **What files are supported?**  
+            #### What files are supported?
             OpenFOAM residual `.dat`, `.log`, and `.txt` files that contain solver residual entries.
 
-            **Are residual plots on log scale?**  
+            #### Are residual plots on log scale?
             Yes. Interactive and static plots use a logarithmic residual axis for convergence analysis.
 
-            **Can I export outputs?**  
+            #### Can I export outputs?
             Yes. Export per-file CSV tables and download all static plot images as a ZIP file.
             """
         )


### PR DESCRIPTION
💡 **What:** Replaced non-semantic `**Bold Text**` with proper semantic heading level 4 (`#### Question?`) in the FAQ expander section.
🎯 **Why:** To improve accessibility. Screen readers rely on semantic headings (like `<h4>`) to understand document hierarchy and navigate content, whereas bolded text is often treated as regular paragraph text.
📸 **Before/After:** The visual hierarchy remains strong, but the underlying markup is now screen-reader friendly.
♿ **Accessibility:** Users relying on assistive technology can now logically jump between FAQ questions using heading navigation shortcuts.

---
*PR created automatically by Jules for task [4303376440226855967](https://jules.google.com/task/4303376440226855967) started by @kastnerp*