### PR TITLE
🎨 Palette: Make Matplotlib line styles colorblind-accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -129,3 +129,7 @@
 ## 2026-04-18 - Semantic Headers and Contextual Column Tooltips
 **Learning:** Using non-semantic markdown formatting (like `**Bold Text**`) to simulate headers prevents screen readers from understanding the document structure, harming accessibility. Additionally, presenting raw variable names as column headers without explanation leaves users guessing their meaning.
 **Action:** Always use semantic markdown headers (like `#### Heading`) to establish proper document hierarchy for assistive technologies. Furthermore, actively use features like the `help` parameter in `st.column_config` to attach descriptive tooltips directly to data table headers, providing necessary context without cluttering the UI.
+
+## 2026-04-18 - Colorblind-Accessible Data Visualizations
+**Learning:** Relying solely on color to differentiate multiple series in a static plot (like Matplotlib) makes the chart unreadable for colorblind users and useless when printed in black-and-white.
+**Action:** Always combine color with a secondary visual channel, such as line styles (`["-", "--", "-.", ":"]` or different markers), to ensure data series remain distinguishable regardless of color perception or medium.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,6 +6,7 @@ import json
 import math
 import traceback
 import re
+import itertools
 import zipfile
 from pathlib import Path
 
@@ -268,12 +269,14 @@ def build_matplotlib_figure(data: pd.DataFrame, *, height_pixels: int, show_grid
     fig, ax = plt.subplots(figsize=(10, fig_height))
     has_series = False
 
+    line_styles = itertools.cycle(["-", "--", "-.", ":"])
+
     for column in ordered_cols:
         residual = pd.to_numeric(data[column], errors="coerce")
         mask = time_values.notna() & residual.notna() & (residual > 0)
         if not mask.any():
             continue
-        ax.plot(time_values[mask], residual[mask], label=column, linewidth=2)
+        ax.plot(time_values[mask], residual[mask], label=column, linewidth=2, linestyle=next(line_styles))
         has_series = True
 
     if not has_series:
@@ -531,9 +534,6 @@ def main() -> None:
                 )
             except Exception as exc:
                 errors.append((uploaded.name, str(exc), traceback.format_exc()))
-
-    ok_count = len(parsed_items)
-    err_count = len(errors)
 
     if "processed_file_ids" not in st.session_state:
         st.session_state.processed_file_ids = set()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -260,7 +260,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int) -> alt.Ch
     return chart
 
 
-def build_matplotlib_figure(data: pd.DataFrame, *, height_pixels: int, show_grid: bool) -> plt.Figure | None:
+def build_matplotlib_figure(data: pd.DataFrame, *, height_pixels: int, show_grid: bool, accessible_line_styles: bool = True) -> plt.Figure | None:
     time_values = pd.to_numeric(data.index.to_series(), errors="coerce")
     ordered_cols = [c for c in FEATURE_COLUMNS if c in data.columns]
     ordered_cols.extend([c for c in data.columns if c not in ordered_cols])
@@ -269,7 +269,10 @@ def build_matplotlib_figure(data: pd.DataFrame, *, height_pixels: int, show_grid
     fig, ax = plt.subplots(figsize=(10, fig_height))
     has_series = False
 
-    line_styles = itertools.cycle(["-", "--", "-.", ":"])
+    if accessible_line_styles:
+        line_styles = itertools.cycle(["-", "--", "-.", ":"])
+    else:
+        line_styles = itertools.cycle(["-"])
 
     for column in ordered_cols:
         residual = pd.to_numeric(data[column], errors="coerce")
@@ -459,6 +462,12 @@ def main() -> None:
             disabled=not has_files,
             help="Displays subtle grid lines on both major and minor ticks to improve readability on logarithmic scales." if has_files else disabled_help,
         )
+        accessible_line_styles = st.checkbox(
+            "Use accessible line styles",
+            value=True,
+            disabled=not has_files,
+            help="Combines colors with different line styles to ensure static plots are readable for colorblind users and in black-and-white." if has_files else disabled_help,
+        )
 
     if not has_files:
         st.info("Upload one or more OpenFOAM residual files to start. Supported formats:", icon=":material/upload_file:")
@@ -590,6 +599,7 @@ def main() -> None:
                 data,
                 height_pixels=static_height,
                 show_grid=show_grid,
+                accessible_line_styles=accessible_line_styles,
             )
             if figure is None:
                 st.warning(f"{name}: no positive residual values to chart (log-scale requires strictly positive values).", icon=":material/warning:")


### PR DESCRIPTION
🎨 **Palette: Colorblind-Accessible Data Visualizations**

💡 **What:** Added cycling line styles (`-`, `--`, `-.`, `:`) to the Matplotlib static plots alongside colors.
🎯 **Why:** Relying solely on color to differentiate lines in a plot makes it completely unreadable for colorblind users or when the plot is printed or viewed in black-and-white. Combining color with a secondary visual channel (line styles) solves this.
♿ **Accessibility:** This directly addresses visual accessibility for static charts.
📸 **Before/After:** Static plots now visually differentiate lines via both color and pattern.

I also documented this critical UX/a11y learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8476156858748096189](https://jules.google.com/task/8476156858748096189) started by @kastnerp*