### PR TITLE
🎨 Palette: Accessible Static Plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -133,3 +133,7 @@
 ## 2026-04-18 - Colorblind-Accessible Data Visualizations
 **Learning:** Relying solely on color to differentiate multiple series in a static plot (like Matplotlib) makes the chart unreadable for colorblind users and useless when printed in black-and-white.
 **Action:** Always combine color with a secondary visual channel, such as line styles (`["-", "--", "-.", ":"]` or different markers), to ensure data series remain distinguishable regardless of color perception or medium.
+
+## 2026-04-19 - Accessible Static Plots
+**Learning:** Streamlit's `st.pyplot()` function natively renders Matplotlib figures as images but lacks any mechanism to provide `alt` text or captions, rendering the plots completely opaque to screen readers.
+**Action:** When rendering static Matplotlib figures, convert the figure to PNG bytes and display it using `st.image(..., caption="...")` instead of `st.pyplot()`. This provides a descriptive text equivalent for visually impaired users. Remember to manually close the Matplotlib figure (`plt.close(fig)`) since `st.pyplot(..., clear_figure=True)` is no longer handling it.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -606,7 +606,8 @@ def main() -> None:
             else:
                 png_bytes = figure_to_png_bytes(figure)
                 static_images.append((name, png_bytes))
-                st.pyplot(figure, clear_figure=True)
+                st.image(png_bytes, caption=f"Static residual plot for {name}", use_container_width=True)
+                plt.close(figure)
                 st.download_button(
                     f"Download Plot Image ({name})",
                     data=png_bytes,


### PR DESCRIPTION
Replaced Streamlit's `st.pyplot()` with `st.image()` for rendering Matplotlib static figures, passing a descriptive `caption` and explicitly closing the figure memory. Added an associated accessibility learning to `.Jules/palette.md`.

`st.pyplot()` internally renders an image but provides no capability to set `alt` text or captions, making the visual completely opaque to screen readers. Using `st.image()` with a caption solves this by providing a text equivalent and enhancing the visual layout.

---
*PR created automatically by Jules for task [11149748919512191987](https://jules.google.com/task/11149748919512191987) started by @kastnerp*