### PR TITLE
🎨 Palette: Improve metric deltas with Order-of-Magnitude context

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -137,3 +137,7 @@
 ## 2026-04-19 - Accessible Static Plots
 **Learning:** Streamlit's `st.pyplot()` function natively renders Matplotlib figures as images but lacks any mechanism to provide `alt` text or captions, rendering the plots completely opaque to screen readers.
 **Action:** When rendering static Matplotlib figures, convert the figure to PNG bytes and display it using `st.image(..., caption="...")` instead of `st.pyplot()`. This provides a descriptive text equivalent for visually impaired users. Remember to manually close the Matplotlib figure (`plt.close(fig)`) since `st.pyplot(..., clear_figure=True)` is no longer handling it.
+
+## 2025-04-21 - Order-of-Magnitude for log-scaled metrics
+**Learning:** Displaying standalone final values (e.g., using `st.metric`) with raw differences for convergence residuals or exponentially decaying data is unintuitive (e.g., -0.09999). It is much harder to scan than order-of-magnitude values.
+**Action:** When displaying log-scaled metrics or properties that span multiple orders of magnitude, use relative Order-of-Magnitude (OoM) drop (e.g., `math.log10(final_val) - math.log10(first_val)`) formatted as `"{oom_diff:+.2f} OoM"` for the `delta` parameter to provide much clearer context on how much the value has changed.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -651,6 +651,11 @@ def main() -> None:
                     first_val = float(clean_series.iloc[0])
                     final_val = float(clean_series.iloc[-1])
                     diff = final_val - first_val
+                    if final_val > 0 and first_val > 0:
+                        oom_diff = math.log10(final_val) - math.log10(first_val)
+                        delta_str = f"{oom_diff:+.2f} OoM"
+                    else:
+                        delta_str = f"{diff:.2e}"
 
                     sparkline_data = [math.log10(v) if v > 0 else 0 for v in clean_series.tolist()]
                     sparkline_data = sparkline_data[::max(1, len(sparkline_data) // 100)]
@@ -659,7 +664,7 @@ def main() -> None:
                         st.metric(
                             label=col,
                             value=f"{final_val:.2e}",
-                            delta=f"{diff:.2e}",
+                            delta=delta_str,
                             delta_color="inverse",
                             border=True,
                             chart_data=sparkline_data,


### PR DESCRIPTION
🎨 Palette: Improve metric deltas with Order-of-Magnitude context

**💡 What:**
Updated the `st.metric` cards in the "Raw Data" tab to calculate and display the relative Order-of-Magnitude (OoM) drop (e.g., `-4.00 OoM`) instead of the raw difference (e.g., `-0.09999`).

**🎯 Why:**
When dealing with exponentially decaying data like OpenFOAM convergence residuals, raw differences are completely unintuitive and hard to read. An Order-of-Magnitude context makes it immediately obvious how much the metric has improved compared to the initial iteration.

**♿ Accessibility:**
Improves scannability and cognitive accessibility by simplifying complex raw numbers into intuitive contextual values. Added documentation to the Palette journal.

---
*PR created automatically by Jules for task [16262038274388165980](https://jules.google.com/task/16262038274388165980) started by @kastnerp*