### PR TITLE
🎨 Palette: Upgrade visual preference settings to toggles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-04-22 - Altair StrokeDash for Colorblind Accessibility
 **Learning:** Relying solely on the `color` encoding in interactive Altair line charts makes them inaccessible to colorblind users. While Streamlit has settings to make static Matplotlib plots accessible via line styles, these are often not propagated to dynamic Altair charts.
 **Action:** When building interactive Altair line charts in Streamlit, link a user-controlled accessibility toggle (like an `accessible_line_styles` checkbox) to dynamically add a `strokeDash` encoding (e.g., `strokeDash=alt.StrokeDash("Variable:N", legend=None)`) alongside `color`. This ensures colorblind users can distinguish series using patterns.
+
+## 2024-05-18 - Use Toggles for Immediate Visual Preferences
+**Learning:** For global settings that instantly toggle visual preferences (like grid lines, dark mode, or accessible line styles), users expect a "switch" interaction rather than a "checkbox" which implies submitting a form.
+**Action:** Use `st.toggle` instead of `st.checkbox` for settings in the sidebar or globally that immediately update the UI without further confirmation.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -461,13 +461,13 @@ def main() -> None:
             disabled=not has_files,
             help="Adjust the vertical size (in pixels) of the static plots." if has_files else disabled_help
         )
-        show_grid = st.checkbox(
+        show_grid = st.toggle(
             "Show static grid",
             value=True,
             disabled=not has_files,
             help="Displays subtle grid lines on both major and minor ticks to improve readability on logarithmic scales." if has_files else disabled_help,
         )
-        accessible_line_styles = st.checkbox(
+        accessible_line_styles = st.toggle(
             "Use accessible line styles",
             value=True,
             disabled=not has_files,
@@ -567,7 +567,7 @@ def main() -> None:
 
     show_names_default = len(parsed_items) > 1
     with filenames_placeholder:
-        show_filenames = st.checkbox(
+        show_filenames = st.toggle(
             "Show filenames",
             value=show_names_default,
             disabled=show_names_default,


### PR DESCRIPTION
💡 **What:** Replaced `st.checkbox` with `st.toggle` for immediate visual preference settings ("Show filenames", "Show static grid", "Use accessible line styles") in the sidebar.
🎯 **Why:** Toggles provide a much better, standard UX for immediate visual preferences than simple checkboxes, which typically imply form submission.
📸 **Before/After:** The sidebar now uses toggle switches for instant settings.
♿ **Accessibility:** Aligns interaction expectations with common "switch" patterns.

---
*PR created automatically by Jules for task [7312905256591225628](https://jules.google.com/task/7312905256591225628) started by @kastnerp*