### PR TITLE
🎨 Palette: Elevate batch actions and fix sparkline artifacts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,11 @@
 ## 2024-05-18 - Use Toggles for Immediate Visual Preferences
 **Learning:** For global settings that instantly toggle visual preferences (like grid lines, dark mode, or accessible line styles), users expect a "switch" interaction rather than a "checkbox" which implies submitting a form.
 **Action:** Use `st.toggle` instead of `st.checkbox` for settings in the sidebar or globally that immediately update the UI without further confirmation.
+
+## 2024-05-18 - Visual Hierarchy for Batch Actions
+**Learning:** Overarching batch actions (like "Export all as .zip") easily get lost among individual file download buttons. Additionally, standard Streamlit buttons can have small click targets, violating Fitts's Law.
+**Action:** Always apply `type="primary"` and `use_container_width=True` to batch action buttons (like `st.download_button` for zip files) to elevate their visual hierarchy and expand their click target, making them clearly distinct from individual item actions.
+
+## 2024-05-18 - Artifact Prevention in Sparklines
+**Learning:** When generating inline sparkline arrays for `st.metric` cards representing log-scaled data (like residuals), naively defaulting non-positive values to `0` (e.g. `[math.log10(v) if v > 0 else 0]`) creates massive, confusing visual spikes on the chart (since $10^0 = 1$), visually implying divergence rather than convergence.
+**Action:** When preparing log-scaled sparkline data, explicitly filter out non-positive values (e.g. `[math.log10(v) for v in data if v > 0]`) to ensure the generated trendline accurately reflects the underlying data without artificial spikes.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -621,6 +621,7 @@ def main() -> None:
                     key=f"static_png_{file_id}",
                     icon=":material/image:",
                     help="Download this static plot as a PNG image.",
+                    use_container_width=True,
                 )
             if idx < len(parsed_items) - 1:
                 st.divider()
@@ -635,6 +636,8 @@ def main() -> None:
                 key="export_all_static_images_zip",
                 icon=":material/folder_zip:",
                 help="Download all static plot images as a single ZIP archive.",
+                type="primary",
+                use_container_width=True,
             )
 
     with tab_table:
@@ -662,7 +665,7 @@ def main() -> None:
                     else:
                         delta_str = f"{diff:.2e}"
 
-                    sparkline_data = [math.log10(v) if v > 0 else 0 for v in clean_series.tolist()]
+                    sparkline_data = [math.log10(v) for v in clean_series.tolist() if v > 0]
                     sparkline_data = sparkline_data[::max(1, len(sparkline_data) // 100)]
 
                     with cols[j]:
@@ -697,6 +700,7 @@ def main() -> None:
                 key=f"table_csv_{file_id}",
                 icon=":material/download:",
                 help="Download the raw residual data as a CSV file.",
+                use_container_width=True,
             )
             if idx < len(parsed_items) - 1:
                 st.divider()
@@ -711,6 +715,8 @@ def main() -> None:
                 key="export_all_data_zip",
                 icon=":material/folder_zip:",
                 help="Download all raw residual data as a single ZIP archive.",
+                type="primary",
+                use_container_width=True,
             )
 
     with st.expander("FAQ: OpenFOAM Residual Plotting", icon=":material/help:"):


### PR DESCRIPTION
🎨 Palette: Elevate batch actions and fix sparkline artifacts

💡 What:
1. Added `use_container_width=True` to all `st.download_button`s.
2. Added `type="primary"` to the "Export all (.zip)" batch action buttons.
3. Fixed sparkline artifact generation by explicitly filtering out non-positive values before log10 transformation.

🎯 Why:
1. Improves Fitts's Law accessibility by expanding click targets, and visually aligns the buttons with the stretched charts above them.
2. Establishes a clear visual hierarchy for terminal, summarized batch actions.
3. Prevents massive, misleading upward spikes on the sparkline when residual values hit zero or underflow, which previously visually implied divergence.

📸 Before/After: Visual changes apply to all download buttons and `st.metric` sparklines.
♿ Accessibility: Larger click targets for all download actions.

---
*PR created automatically by Jules for task [17280077323982580783](https://jules.google.com/task/17280077323982580783) started by @kastnerp*