### PR TITLE
🎨 Palette: Merge Altair legends for colorblind accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-04-26 - Merge Altair Encodings for Cohesive Accessibility Legends
+**Learning:** When using secondary visual encodings (like `strokeDash`) alongside `color` for colorblind accessibility in Altair, setting `legend=None` on the secondary encoding omits its pattern from the legend entirely. This prevents visually impaired users from mapping legend items to chart lines.
+**Action:** To force Vega-Lite to merge the color and line style visual cues into a single cohesive legend, ensure both the `color` and `strokeDash` encodings share the exact same `legend` configuration (e.g., matching titles) and `sort` order. Never use `legend=None` for the secondary encoding.
+
 ## 2026-04-22 - Altair StrokeDash for Colorblind Accessibility
 **Learning:** Relying solely on the `color` encoding in interactive Altair line charts makes them inaccessible to colorblind users. While Streamlit has settings to make static Matplotlib plots accessible via line styles, these are often not propagated to dynamic Altair charts.
 **Action:** When building interactive Altair line charts in Streamlit, link a user-controlled accessibility toggle (like an `accessible_line_styles` checkbox) to dynamically add a `strokeDash` encoding (e.g., `strokeDash=alt.StrokeDash("Variable:N", legend=None)`) alongside `color`. This ensures colorblind users can distinguish series using patterns.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -247,7 +247,11 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
     }
 
     if accessible_line_styles:
-        encode_args["strokeDash"] = alt.StrokeDash("Variable:N", legend=None)
+        encode_args["strokeDash"] = alt.StrokeDash(
+            "Variable:N",
+            sort=ordered_cols,
+            legend=alt.Legend(title="Variable (click to isolate)")
+        )
 
     chart = (
         alt.Chart(long_frame)


### PR DESCRIPTION
💡 **What**: The UX enhancement added ensures that the interactive Altair chart merges both `color` and `strokeDash` visual encodings into a single cohesive legend.
🎯 **Why**: Previously, the `strokeDash` encoding was configured with `legend=None`. This omitted the pattern information from the legend entirely, meaning that while the chart lines had different patterns, users couldn't tell which pattern corresponded to which variable.
♿ **Accessibility**: This makes the chart significantly more accessible to colorblind users, as they can now map the legend items to the chart lines using the line pattern (stroke dash) rather than relying solely on color.

---
*PR created automatically by Jules for task [16589107175287100586](https://jules.google.com/task/16589107175287100586) started by @kastnerp*