### PR TITLE
🎨 Palette: Accessible legend merging for Altair interactive chart

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,6 +1,6 @@
 ## 2026-04-22 - Altair StrokeDash for Colorblind Accessibility
 **Learning:** Relying solely on the `color` encoding in interactive Altair line charts makes them inaccessible to colorblind users. While Streamlit has settings to make static Matplotlib plots accessible via line styles, these are often not propagated to dynamic Altair charts.
-**Action:** When building interactive Altair line charts in Streamlit, link a user-controlled accessibility toggle (like an `accessible_line_styles` checkbox) to dynamically add a `strokeDash` encoding (e.g., `strokeDash=alt.StrokeDash("Variable:N", legend=None)`) alongside `color`. This ensures colorblind users can distinguish series using patterns.
+**Action:** When building interactive Altair line charts in Streamlit, link a user-controlled accessibility toggle (like an `accessible_line_styles` checkbox) to dynamically add a `strokeDash` encoding alongside `color`. To force Vega-Lite to merge the color and line style visual cues into a single, cohesive legend, ensure both the `color` and `strokeDash` encodings share the exact same `legend` configuration (e.g., matching titles) and `sort` order. Never use `legend=None` for the secondary encoding, as it will omit those cues from the legend entirely.
 
 ## 2024-05-18 - Use Toggles for Immediate Visual Preferences
 **Learning:** For global settings that instantly toggle visual preferences (like grid lines, dark mode, or accessible line styles), users expect a "switch" interaction rather than a "checkbox" which implies submitting a form.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -247,7 +247,11 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
     }
 
     if accessible_line_styles:
-        encode_args["strokeDash"] = alt.StrokeDash("Variable:N", legend=None)
+        encode_args["strokeDash"] = alt.StrokeDash(
+            "Variable:N",
+            sort=ordered_cols,
+            legend=alt.Legend(title="Variable (click to isolate)")
+        )
 
     chart = (
         alt.Chart(long_frame)


### PR DESCRIPTION
💡 **What**: The UX enhancement added:
Updated the `strokeDash` encoding in `streamlit_app.py`'s interactive plot to use the same `sort` and `legend` arguments as the `color` encoding instead of `legend=None`.

🎯 **Why**: The user problem it solves:
When `accessible_line_styles` was toggled on, the interactive chart correctly rendered dashed lines to help colorblind users distinguish series. However, because `legend=None` was passed to the `strokeDash` encoding, those visual patterns were completely omitted from the legend itself, forcing users to guess which pattern corresponded to which variable. By mirroring the legend configurations, Vega-Lite automatically merges them into a single legend showing both the color and the dash pattern.

♿ **Accessibility**: Any a11y improvements made:
Significantly improves accessibility for color-vision-deficient users interacting with the dynamic Altair convergence charts, ensuring they can actually interpret the chart legend. Added a learning to `.Jules/palette.md` to document this Vega-Lite behavior.

---
*PR created automatically by Jules for task [118347274346630541](https://jules.google.com/task/118347274346630541) started by @kastnerp*