### PR TITLE
🎨 Palette: Enhance accessible line styles with colorblind-safe palettes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2024-05-19 - Merging Multiple Encodings into One Altair Legend
 **Learning:** When making an interactive Altair chart accessible with secondary encodings (like `strokeDash` alongside `color`), providing `legend=None` to the secondary encoding completely omits those visual cues from the legend. This leaves colorblind users unable to map the line styles to their respective variables.
 **Action:** To force Vega-Lite to merge multiple encodings (e.g., color and line style) into a single, fully accessible legend, ensure that both encodings share the exact same `legend` configuration (e.g., matching titles) and the exact same `sort` order.
+
+## 2026-04-28 - Colorblind Safe Palettes in Streamlit Charts
+**Learning:** While combining line styles with colors improves accessibility in charts, the default categorical color palettes (like `category10` in Vega-Lite or `default` in Matplotlib) are not fully colorblind safe. This can still make distinguishing between variables difficult even with different dash patterns.
+**Action:** When implementing an accessibility toggle for charts, actively switch the color scales to colorblind-safe schemes (like `scheme="dark2"` for Altair and `plt.style.context("tableau-colorblind10")` for Matplotlib) in addition to applying varying line styles. This provides robust multi-channel differentiation.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -247,6 +247,12 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
     }
 
     if accessible_line_styles:
+        encode_args["color"] = alt.Color(
+            "Variable:N",
+            sort=ordered_cols,
+            legend=alt.Legend(title="Variable (click to isolate)"),
+            scale=alt.Scale(scheme="dark2"),
+        )
         encode_args["strokeDash"] = alt.StrokeDash(
             "Variable:N",
             sort=ordered_cols,
@@ -275,34 +281,37 @@ def build_matplotlib_figure(data: pd.DataFrame, *, height_pixels: int, show_grid
     ordered_cols.extend([c for c in data.columns if c not in ordered_cols])
 
     fig_height = max(2.4, height_pixels / 100.0)
-    fig, ax = plt.subplots(figsize=(10, fig_height))
-    has_series = False
 
-    if accessible_line_styles:
-        line_styles = itertools.cycle(["-", "--", "-.", ":"])
-    else:
-        line_styles = itertools.cycle(["-"])
+    style = "tableau-colorblind10" if accessible_line_styles else "default"
+    with plt.style.context(style):
+        fig, ax = plt.subplots(figsize=(10, fig_height))
+        has_series = False
 
-    for column in ordered_cols:
-        residual = pd.to_numeric(data[column], errors="coerce")
-        mask = time_values.notna() & residual.notna() & (residual > 0)
-        if not mask.any():
-            continue
-        ax.plot(time_values[mask], residual[mask], label=column, linewidth=2, linestyle=next(line_styles))
-        has_series = True
+        if accessible_line_styles:
+            line_styles = itertools.cycle(["-", "--", "-.", ":"])
+        else:
+            line_styles = itertools.cycle(["-"])
 
-    if not has_series:
-        plt.close(fig)
-        return None
+        for column in ordered_cols:
+            residual = pd.to_numeric(data[column], errors="coerce")
+            mask = time_values.notna() & residual.notna() & (residual > 0)
+            if not mask.any():
+                continue
+            ax.plot(time_values[mask], residual[mask], label=column, linewidth=2, linestyle=next(line_styles))
+            has_series = True
 
-    ax.set_xlabel("Iterations")
-    ax.set_ylabel("Residuals")
-    ax.set_yscale("log")
-    if show_grid:
-        ax.grid(True, which="both", linestyle="--", linewidth=0.5, alpha=0.4)
-    ax.legend(loc="best")
-    fig.tight_layout()
-    return fig
+        if not has_series:
+            plt.close(fig)
+            return None
+
+        ax.set_xlabel("Iterations")
+        ax.set_ylabel("Residuals")
+        ax.set_yscale("log")
+        if show_grid:
+            ax.grid(True, which="both", linestyle="--", linewidth=0.5, alpha=0.4)
+        ax.legend(loc="best")
+        fig.tight_layout()
+        return fig
 
 
 def figure_to_png_bytes(figure: plt.Figure, *, dpi: int = 200) -> bytes:


### PR DESCRIPTION
**💡 What:** Updated the `accessible_line_styles` toggle to switch the chart color schemes to colorblind-safe palettes (`dark2` for Altair, `tableau-colorblind10` for Matplotlib) in addition to applying different line dash styles. Added a journal entry to `.Jules/palette.md` detailing this learning.

**🎯 Why:** Standard categorical color palettes (like Matplotlib's default or Vega-Lite's categorical defaults) are not colorblind-safe. When users rely on color to distinguish lines, having just dashed lines might still leave the chart confusing if the baseline colors are indistinguishable. Combining both a colorblind-friendly palette and line styles provides robust, multi-channel accessibility.

**📸 Before/After:**
*(Visual changes verified locally via Playwright screenshots)*
- **Before:** When `accessible_line_styles` was toggled, charts gained dashed lines but retained the default colors (which could blend together for colorblind users).
- **After:** When `accessible_line_styles` is toggled, charts gain dashed lines *and* switch to high-contrast, colorblind-safe palettes (`dark2` / `tableau-colorblind10`), making differentiation drastically easier.

**♿ Accessibility:** Greatly improves the readability of multi-series charts for users with color vision deficiencies by adding color-based differentiation on top of pattern-based differentiation.

---
*PR created automatically by Jules for task [334005006577218542](https://jules.google.com/task/334005006577218542) started by @kastnerp*