### PR TITLE
🎨 Palette: Add cognitive chunking to sidebar

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-04-28 - Colorblind Safe Palettes in Streamlit Charts
 **Learning:** While combining line styles with colors improves accessibility in charts, the default categorical color palettes (like `category10` in Vega-Lite or `default` in Matplotlib) are not fully colorblind safe. This can still make distinguishing between variables difficult even with different dash patterns.
 **Action:** When implementing an accessibility toggle for charts, actively switch the color scales to colorblind-safe schemes (like `scheme="dark2"` for Altair and `plt.style.context("tableau-colorblind10")` for Matplotlib) in addition to applying varying line styles. This provides robust multi-channel differentiation.
+
+## 2026-04-30 - Cognitive Chunking in Configuration Sidebars
+**Learning:** When sidebars accumulate multiple independent settings (e.g., plot dimensions alongside accessibility toggles), presenting them as a flat list increases cognitive load and degrades discoverability.
+**Action:** Use `st.markdown("#### Category Name")` and `st.divider()` in Streamlit to create semantic groups (cognitive chunking). This visual hierarchy helps users quickly locate specific classes of settings without scanning the entire list.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -462,6 +462,8 @@ def main() -> None:
     with st.sidebar:
         st.header("⚙️ Plot Settings")
         filenames_placeholder = st.empty()
+
+        st.markdown("#### Plot Dimensions")
         interactive_height = st.slider(
             "Interactive plot height", 240, 900, 420, 20,
             format="%d px",
@@ -474,6 +476,9 @@ def main() -> None:
             disabled=not has_files,
             help="Adjust the vertical size (in pixels) of the static plots." if has_files else disabled_help
         )
+
+        st.divider()
+        st.markdown("#### Styling & Accessibility")
         show_grid = st.toggle(
             "Show static grid",
             value=True,
@@ -484,7 +489,7 @@ def main() -> None:
             "Use accessible line styles",
             value=True,
             disabled=not has_files,
-            help="Combines colors with different line styles to ensure static plots are readable for colorblind users and in black-and-white." if has_files else disabled_help,
+            help="Combines colors with different line styles to ensure both interactive and static plots are readable for colorblind users and in black-and-white." if has_files else disabled_help,
         )
 
     if not has_files:
@@ -537,7 +542,7 @@ def main() -> None:
         files_to_process = [DummyFile("test_residual.dat", sample_data)]
 
         st.info("Currently viewing sample data.", icon=":material/visibility:")
-        if st.button("Clear sample data", icon=":material/close:", help="Clear the sample data to upload your own files."):
+        if st.button("Clear sample data", icon=":material/close:", use_container_width=True, help="Clear the sample data to upload your own files."):
             st.session_state.use_sample_data = False
             st.rerun()
     else:


### PR DESCRIPTION
💡 **What**: Added semantic headings (`#### Plot Dimensions` and `#### Styling & Accessibility`) and a divider (`st.divider()`) to the sidebar. Also, corrected a tooltip text and applied `use_container_width=True` to the "Clear sample data" button.
🎯 **Why**: To improve visual hierarchy and create cognitive chunking in the settings sidebar, reducing user cognitive load. The full-width button improves the click target size according to Fitts's Law.
📸 **Before/After**: See the attached UI screenshots for the sidebar and button changes.
♿ **Accessibility**: Improves scan-ability for both visual users and screen readers navigating the sidebar layout.

---
*PR created automatically by Jules for task [4864120900562519599](https://jules.google.com/task/4864120900562519599) started by @kastnerp*