### PR TITLE
🎨 Palette: Enhance heading scannability with Material Icons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-04-30 - Cognitive Chunking in Configuration Sidebars
 **Learning:** When sidebars accumulate multiple independent settings (e.g., plot dimensions alongside accessibility toggles), presenting them as a flat list increases cognitive load and degrades discoverability.
 **Action:** Use `st.markdown("#### Category Name")` and `st.divider()` in Streamlit to create semantic groups (cognitive chunking). This visual hierarchy helps users quickly locate specific classes of settings without scanning the entire list.
+
+## 2026-04-30 - Material Icons for Consistent Scannability in Headings
+**Learning:** Using OS-dependent emojis (like ⚙️) or plain text for semantic headers creates inconsistent visual experiences across platforms and breaks visual harmony with components that natively support Streamlit Material icons (like buttons, tabs, or toasts).
+**Action:** Always prefer embedding Streamlit Material Design icon syntax (e.g., `:material/settings:`) directly into markdown headings (`st.markdown("#### :material/icon: Title")` or `st.header(":material/icon: Title")`) to establish a consistent, polished visual hierarchy and improve cognitive chunking and scannability.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -460,10 +460,10 @@ def main() -> None:
     disabled_help = "⚠️ Please upload a residual file first to enable this setting."
 
     with st.sidebar:
-        st.header("⚙️ Plot Settings")
+        st.header(":material/settings: Plot Settings")
         filenames_placeholder = st.empty()
 
-        st.markdown("#### Plot Dimensions")
+        st.markdown("#### :material/straighten: Plot Dimensions")
         interactive_height = st.slider(
             "Interactive plot height", 240, 900, 420, 20,
             format="%d px",
@@ -478,7 +478,7 @@ def main() -> None:
         )
 
         st.divider()
-        st.markdown("#### Styling & Accessibility")
+        st.markdown("#### :material/accessibility_new: Styling & Accessibility")
         show_grid = st.toggle(
             "Show static grid",
             value=True,
@@ -667,7 +667,7 @@ def main() -> None:
             if show_filenames:
                 st.subheader(name)
 
-            st.markdown("#### Final Convergence Summary")
+            st.markdown("#### :material/summarize: Final Convergence Summary")
             valid_cols = [c for c in data.columns if not data[c].dropna().empty]
 
             for i in range(0, len(valid_cols), 4):
@@ -740,13 +740,13 @@ def main() -> None:
     with st.expander("FAQ: OpenFOAM Residual Plotting", icon=":material/help:"):
         st.markdown(
             """
-            #### What files are supported?
+            #### :material/file_present: What files are supported?
             OpenFOAM residual `.dat`, `.log`, and `.txt` files that contain solver residual entries.
 
-            #### Are residual plots on log scale?
+            #### :material/show_chart: Are residual plots on log scale?
             Yes. Interactive and static plots use a logarithmic residual axis for convergence analysis.
 
-            #### Can I export outputs?
+            #### :material/download: Can I export outputs?
             Yes. Export per-file CSV tables and download all static plot images as a ZIP file.
             """
         )


### PR DESCRIPTION
💡 **What**: Added Streamlit Material Design icon syntax (e.g. `:material/settings:`) to multiple `st.header` and `st.markdown("#### ...")` semantic headers. Replaced cross-platform inconsistent emojis like `⚙️`.
🎯 **Why**: Using consistent web fonts for icons instead of OS-native emojis (which vary wildly between macOS, Windows, and Linux) provides better visual chunking and scannability while keeping the UI visually harmonious with other built-in components like tabs and buttons.
♿ **Accessibility**: Streamlit handles material icons smoothly, and having uniform headings improves cognitive load for users scanning the application layout.

---
*PR created automatically by Jules for task [6526177568837940110](https://jules.google.com/task/6526177568837940110) started by @kastnerp*