### PR TITLE
🎨 Palette: Add contextual file icons to subheaders

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
+## 2026-05-02 - Contextual Icons for Comparison Views
+**Learning:** In multi-file upload workflows or comparison views where repeated items (like charts or tables) are stacked vertically, using plain text headings for filenames makes scanning and distinguishing file types cognitively demanding.
+**Action:** Dynamically inject format-specific Streamlit Material icons (e.g., `:material/article:` for `.log` files, `:material/description:` for `.dat` files) directly into repeated `st.subheader` strings. This creates a strong visual hierarchy, improves cognitive chunking, and allows users to quickly scan and differentiate file types at a glance.
+
 ## 2026-04-26 - Merge Altair Encodings for Cohesive Accessibility Legends
 **Learning:** When using secondary visual encodings (like `strokeDash`) alongside `color` for colorblind accessibility in Altair, setting `legend=None` on the secondary encoding omits its pattern from the legend entirely. This prevents visually impaired users from mapping legend items to chart lines.
 **Action:** To force Vega-Lite to merge the color and line style visual cues into a single cohesive legend, ensure both the `color` and `strokeDash` encodings share the exact same `legend` configuration (e.g., matching titles) and `sort` order. Never use `legend=None` for the secondary encoding.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -427,6 +427,10 @@ def make_file_id(name: str, raw_bytes: bytes) -> str:
     return f"{name}-{digest}"
 
 
+def get_file_icon(filename: str) -> str:
+    return ":material/article:" if filename.lower().endswith((".log", ".out", ".txt")) else ":material/description:"
+
+
 def main() -> None:
     st.set_page_config(page_title=SEO_TITLE, page_icon="📈")
     inject_seo_metadata()
@@ -600,7 +604,7 @@ def main() -> None:
             file_id = str(item["file_id"])
             data = item["data"]
             if show_filenames:
-                st.subheader(name)
+                st.subheader(f"{get_file_icon(name)} {name}")
             chart = build_chart(data, interactive=True, height=interactive_height, accessible_line_styles=accessible_line_styles)
             if chart is None:
                 st.warning(f"{name}: no positive residual values to chart (log-scale requires strictly positive values).", icon=":material/warning:")
@@ -617,7 +621,7 @@ def main() -> None:
             file_id = str(item["file_id"])
             data = item["data"]
             if show_filenames:
-                st.subheader(name)
+                st.subheader(f"{get_file_icon(name)} {name}")
             figure = build_matplotlib_figure(
                 data,
                 height_pixels=static_height,
@@ -665,7 +669,7 @@ def main() -> None:
             file_id = str(item["file_id"])
             data = item["data"]
             if show_filenames:
-                st.subheader(name)
+                st.subheader(f"{get_file_icon(name)} {name}")
 
             st.markdown("#### :material/summarize: Final Convergence Summary")
             valid_cols = [c for c in data.columns if not data[c].dropna().empty]


### PR DESCRIPTION
This PR introduces a micro-UX improvement by dynamically injecting format-specific Streamlit Material icons (e.g., `:material/article:` for `.log` files, `:material/description:` for `.dat` files) into the filename subheaders displayed above charts and tables.

💡 **What:** Added `get_file_icon` helper to prefix `st.subheader` calls with appropriate Material Design icons based on file extensions.
🎯 **Why:** In multi-file upload workflows and comparison views, repeated plain-text headings make scanning and distinguishing file types cognitively demanding. Injecting contextual icons creates a strong visual hierarchy, improves cognitive chunking, and allows users to quickly scan and differentiate file types (logs vs. dat) at a glance.
♿ **Accessibility:** Enhances cognitive accessibility by providing an additional visual cue beyond text alone.

---
*PR created automatically by Jules for task [11732025276898456826](https://jules.google.com/task/11732025276898456826) started by @kastnerp*