### PR TITLE
🎨 Palette: Format interactive plot axis with scientific notation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-05-03 - Consistent Sidebar Layouts without DuplicateWidgetID Exceptions
 **Learning:** Attempting to pre-render a "disabled" UI control (like `st.toggle`) in a placeholder and then overwriting it *later in the same script execution* causes a fatal `DuplicateWidgetID` error in Streamlit, because Streamlit registers both widget calls even if they target the same `st.empty()`.
 **Action:** To prevent layout shifts for controls that depend on parsed data while avoiding duplicate widget errors, inspect the input data *before* rendering the sidebar. This allows you to render the control statically exactly once (with the correct active/disabled state computed upfront) within its semantic group, ensuring visual chunking and layout stability without brittle placeholder overwriting.
+
+## 2026-05-06 - Explicit Scientific Notation for Log-Scaled Engineering Axes
+**Learning:** When visualizing small engineering values (like CFD residuals) on a log-scaled axis in Altair/Vega-Lite, the default axis formatting often fails to render very small numbers legibly, either dropping them to `0` or creating extremely long decimals that clip text.
+**Action:** Always explicitly specify scientific notation for the axis formatting (e.g., `axis=alt.Axis(format="e")`) when dealing with small, log-scaled engineering variables. This aligns with domain conventions, maintains precise scaling visibility, and prevents text clipping in the UI.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -231,6 +231,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
             "Residual:Q",
             title="Residuals",
             scale=alt.Scale(type="log"),
+            axis=alt.Axis(format="e"),
         ),
         "color": alt.Color(
             "Variable:N",


### PR DESCRIPTION
💡 **What:** Added explicit scientific notation formatting (`format="e"`) to the log-scaled Y-axis of the Altair interactive plot.
🎯 **Why:** When visualizing very small engineering values (like CFD residuals which often drop to $10^{-6}$), Altair's default log axis formatting can fail to render labels legibly. It either drops small values to `0` or produces extremely long decimals that visually clip off the side of the chart. Forcing scientific notation perfectly aligns with CFD domain conventions and prevents these visual bugs.
♿ **Accessibility/UX:** Improves the legibility and mathematical precision of the chart axis.
📸 **Before/After:** The Y-axis now correctly reads `1e+0`, `5e-1`, `1e-1`, etc.

---
*PR created automatically by Jules for task [10454947421735523415](https://jules.google.com/task/10454947421735523415) started by @kastnerp*