### PR TITLE
🎨 Palette: Enhance Altair chart X-axis scaling to prevent data compression

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,6 @@
 ## 2026-05-06 - Explicit Scientific Notation for Log-Scaled Engineering Axes
 **Learning:** When visualizing small engineering values (like CFD residuals) on a log-scaled axis in Altair/Vega-Lite, the default axis formatting often fails to render very small numbers legibly, either dropping them to `0` or creating extremely long decimals that clip text.
 **Action:** Always explicitly specify scientific notation for the axis formatting (e.g., `axis=alt.Axis(format="e")`) when dealing with small, log-scaled engineering variables. This aligns with domain conventions, maintains precise scaling visibility, and prevents text clipping in the UI.
+## 2025-05-08 - [Altair Quantitative Axes Default to Zero]
+**Learning:** By default, Altair (Vega-Lite) quantitative axes (`:Q`) include `0`, which can severely compress data when visualizing time series or offset values (e.g., iterations starting at 10,000).
+**Action:** Use `scale=alt.Scale(zero=False)` explicitly when plotting quantitative offset data like iterations, times, or dates that are far from zero to ensure the data fills the chart area optimally.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -226,7 +226,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
     )
 
     encode_args = {
-        "x": alt.X("Time:Q", title="Iterations"),
+        "x": alt.X("Time:Q", title="Iterations", scale=alt.Scale(zero=False)),
         "y": alt.Y(
             "Residual:Q",
             title="Residuals",


### PR DESCRIPTION
🎨 Palette: Enhance Altair chart X-axis scaling to prevent data compression

💡 What: Modified the `x` encoding in `build_chart` to use `scale=alt.Scale(zero=False)`.
🎯 Why: Altair defaults to starting quantitative axes at zero. When plotting OpenFOAM iterations from restarted simulations (e.g., iterations starting at 10,000 or even 1.0 vs 2.0 in the sample data), forcing a 0 bound artificially compresses the data into a small portion of the chart area. Disabling the `zero` requirement allows the chart to perfectly fit the data domain.
📸 Before/After: Verified via Playwright screenshot; the chart perfectly fills the width based on the actual iteration values.
♿ Accessibility: Ensures that trendline slopes are legible regardless of the iteration offset.

---
*PR created automatically by Jules for task [17701853494273025822](https://jules.google.com/task/17701853494273025822) started by @kastnerp*