### PR TITLE
🎨 Palette: Prevent vertical zooming on log-scaled residual charts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -48,3 +48,7 @@
 ## 2025-05-08 - [Altair Quantitative Axes Default to Zero]
 **Learning:** By default, Altair (Vega-Lite) quantitative axes (`:Q`) include `0`, which can severely compress data when visualizing time series or offset values (e.g., iterations starting at 10,000).
 **Action:** Use `scale=alt.Scale(zero=False)` explicitly when plotting quantitative offset data like iterations, times, or dates that are far from zero to ensure the data fills the chart area optimally.
+
+## 2026-05-10 - Unidirectional Zooming for Time-Series Logs
+**Learning:** When users interact with a time-series chart (or convergence plot) that uses a log-scaled Y-axis, allowing default two-dimensional zooming (both X and Y axes) is highly disorienting. Zooming on a log-scaled Y-axis distorts the relative magnitude of values and quickly leads to users getting "lost" in the plot.
+**Action:** When enabling interactivity (panning/zooming) on Altair charts where the Y-axis represents magnitude or uses a log scale over time/iterations, restrict the interactivity solely to the X-axis using `chart.interactive(bind_y=False)`. This preserves the vertical scale perspective while allowing users to scrub through the time domain.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -272,7 +272,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
     )
 
     if interactive:
-        return chart.interactive()
+        return chart.interactive(bind_y=False)
     return chart
 
 


### PR DESCRIPTION
🎨 Palette: Prevent vertical zooming on log-scaled residual charts

💡 What: Restricted the interactive zooming behavior of the Altair residual charts to only operate along the X-axis (iterations/time).
🎯 Why: Because the Y-axis represents residual magnitudes on a logarithmic scale, allowing 2D zooming quickly distorts the magnitude perspective and causes users to get "lost" in the plot space. Constraining panning/zooming to the X-axis preserves the critical vertical context while allowing time-domain exploration.
♿ Accessibility: Improves spatial orientation for users exploring complex simulation data.

---
*PR created automatically by Jules for task [17638399438048471099](https://jules.google.com/task/17638399438048471099) started by @kastnerp*