### PR TITLE
🎨 Palette: Expose multi-select in chart legend

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -52,3 +52,7 @@
 ## 2026-05-10 - Unidirectional Zooming for Time-Series Logs
 **Learning:** When users interact with a time-series chart (or convergence plot) that uses a log-scaled Y-axis, allowing default two-dimensional zooming (both X and Y axes) is highly disorienting. Zooming on a log-scaled Y-axis distorts the relative magnitude of values and quickly leads to users getting "lost" in the plot.
 **Action:** When enabling interactivity (panning/zooming) on Altair charts where the Y-axis represents magnitude or uses a log scale over time/iterations, restrict the interactivity solely to the X-axis using `chart.interactive(bind_y=False)`. This preserves the vertical scale perspective while allowing users to scrub through the time domain.
+
+## 2026-05-15 - Expose Hidden Interactivity in Legends
+**Learning:** Native visualization capabilities like Altair/Vega-Lite's `shift-click` multi-select functionality in interactive legends are completely invisible by default. This makes the feature undiscoverable for sighted users and inaccessible for screen reader users unless explicitly documented in the UI.
+**Action:** When enabling interactive selections (e.g. `bind='legend'`) in charts, explicitly append instructions for advanced modifier key interactions directly into the legend title (e.g., `title="Variable (click to isolate, shift-click for multiple)"`) and the chart's ARIA `description` to ensure the interaction is discoverable and accessible to all users.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -236,7 +236,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
         "color": alt.Color(
             "Variable:N",
             sort=ordered_cols,
-            legend=alt.Legend(title="Variable (click to isolate)")
+            legend=alt.Legend(title=["Variable", "(click to isolate,", "shift-click to multi-select)"])
         ),
         "opacity": alt.condition(selection, alt.value(1.0), alt.value(0.2)),
         "strokeWidth": alt.condition(hover, alt.value(3), alt.value(1.5)),
@@ -251,13 +251,13 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
         encode_args["color"] = alt.Color(
             "Variable:N",
             sort=ordered_cols,
-            legend=alt.Legend(title="Variable (click to isolate)"),
+            legend=alt.Legend(title=["Variable", "(click to isolate,", "shift-click to multi-select)"]),
             scale=alt.Scale(scheme="dark2"),
         )
         encode_args["strokeDash"] = alt.StrokeDash(
             "Variable:N",
             sort=ordered_cols,
-            legend=alt.Legend(title="Variable (click to isolate)")
+            legend=alt.Legend(title=["Variable", "(click to isolate,", "shift-click to multi-select)"])
         )
 
     chart = (
@@ -267,7 +267,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
         .add_params(selection, hover)
         .properties(
             height=height,
-            description=f"Interactive line chart showing OpenFOAM residual convergence over iterations for variables: {', '.join(ordered_cols)}. Use the legend to isolate specific variables."
+            description=f"Interactive line chart showing OpenFOAM residual convergence over iterations for variables: {', '.join(ordered_cols)}. Use the legend to isolate specific variables, or shift-click to select multiple."
         )
     )
 


### PR DESCRIPTION
💡 What: Added explicit instructions to the Altair legend title (as a multi-line string array to prevent truncation) and ARIA description indicating that users can `shift-click` to multi-select.
🎯 Why: Native Altair interactive capabilities like `shift-click` multi-select are invisible by default. This makes the feature discoverable for all users and prevents the instructional text from being cut off.
📸 Before/After: Legend titles changed from `Variable (click to isolate)` to `Variable \n (click to isolate, \n shift-click to multi-select)`.
♿ Accessibility: Updated the chart's ARIA description so screen-reader users are also aware of the multi-select interaction.

---
*PR created automatically by Jules for task [9691712756179208120](https://jules.google.com/task/9691712756179208120) started by @kastnerp*