### PR TITLE
🎨 Palette: Improve scannability of long text in code blocks

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -56,3 +56,7 @@
 ## 2026-05-15 - Expose Hidden Interactivity in Legends
 **Learning:** Native visualization capabilities like Altair/Vega-Lite's `shift-click` multi-select functionality in interactive legends are completely invisible by default. This makes the feature undiscoverable for sighted users and inaccessible for screen reader users unless explicitly documented in the UI.
 **Action:** When enabling interactive selections (e.g. `bind='legend'`) in charts, explicitly append instructions for advanced modifier key interactions directly into the legend title (e.g., `title="Variable (click to isolate, shift-click for multiple)"`) and the chart's ARIA `description` to ensure the interaction is discoverable and accessible to all users.
+
+## 2026-05-18 - Wrapping Lines in Code Blocks for Scannability
+**Learning:** When displaying long text lines (such as OpenFOAM log file lines or Python tracebacks) inside code blocks (`st.code`), the default horizontal scrolling makes the text extremely difficult to read and breaks the flow of scanning the UI.
+**Action:** Always enable line wrapping (`wrap_lines=True`) in `st.code` blocks when displaying content that is expected to have long lines (like log file examples or error tracebacks) to improve scannability and ensure users can see the full context without tedious horizontal scrolling.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -530,9 +530,9 @@ def main() -> None:
         st.info("Upload one or more OpenFOAM residual files to start. Supported formats:", icon=":material/upload_file:")
         tab_dat, tab_log = st.tabs([":material/description: .dat Example", ":material/article: .log Example"])
         with tab_dat:
-            st.code("# OpenFOAM\n# Time alpha beta gamma\n1 0.1 0.2 0.3\n2 0.01 0.02 0.03", language="text")
+            st.code("# OpenFOAM\n# Time alpha beta gamma\n1 0.1 0.2 0.3\n2 0.01 0.02 0.03", language="text", wrap_lines=True)
         with tab_log:
-            st.code("Time = 1\nSolving for Ux, Initial residual = 0.1, Final residual = 0.01, No Iterations 10\nSolving for Uy, Initial residual = 0.2, Final residual = 0.02, No Iterations 10", language="text")
+            st.code("Time = 1\nSolving for Ux, Initial residual = 0.1, Final residual = 0.01, No Iterations 10\nSolving for Uy, Initial residual = 0.2, Final residual = 0.02, No Iterations 10", language="text", wrap_lines=True)
 
         # Load sample data robustly using path relative to this script
         sample_path = Path(__file__).parent / "test_residual.dat"
@@ -598,7 +598,7 @@ def main() -> None:
     for filename, message, tb in errors:
         st.error(f"**{filename}**: {message}", icon=":material/error:")
         with st.expander("View error details", icon=":material/bug_report:"):
-            st.code(tb, language="python")
+            st.code(tb, language="python", wrap_lines=True)
 
     if not parsed_items:
         return


### PR DESCRIPTION
🎨 Palette: Improve scannability of long text in code blocks

💡 What: Added `wrap_lines=True` to the `st.code` blocks used for the `.dat` and `.log` file examples in the empty state, as well as the error traceback expander.
🎯 Why: Long lines (like OpenFOAM log file lines or Python tracebacks) inside code blocks default to horizontal scrolling, which makes the text extremely difficult to read and breaks the flow of scanning the UI. Wrapping the lines ensures the full context is visible within the layout.
📸 Before/After: Visual verification confirmed the text wraps gracefully on narrower screens.
♿ Accessibility: Reduces cognitive load and tedious scrolling interactions when diagnosing errors or reading examples.

---
*PR created automatically by Jules for task [16631758649275757202](https://jules.google.com/task/16631758649275757202) started by @kastnerp*