### PR TITLE
🎨 Palette: Expose invisible chart interactions & clarify tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -60,3 +60,7 @@
 ## 2026-05-18 - Wrapping Lines in Code Blocks for Scannability
 **Learning:** When displaying long text lines (such as OpenFOAM log file lines or Python tracebacks) inside code blocks (`st.code`), the default horizontal scrolling makes the text extremely difficult to read and breaks the flow of scanning the UI.
 **Action:** Always enable line wrapping (`wrap_lines=True`) in `st.code` blocks when displaying content that is expected to have long lines (like log file examples or error tracebacks) to improve scannability and ensure users can see the full context without tedious horizontal scrolling.
+
+## 2026-05-19 - Expose Invisible Interactions (Zoom/Pan) in Charts
+**Learning:** Native chart interactions like scrolling to zoom or dragging to pan are completely invisible affordances. Users may not realize they can interact with the visualization, especially when specific axes are constrained (e.g., vertical zooming disabled).
+**Action:** Always provide explicit, concise instructions (e.g., via `st.caption` with an icon) near the interactive chart explaining how to navigate the visualization. This ensures that powerful interactions are discoverable rather than hidden.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -606,6 +606,10 @@ def main() -> None:
     tab_interactive, tab_static, tab_table = st.tabs([":material/show_chart: Interactive Plot", ":material/image: Static Plot", ":material/table_view: Raw Data"])
 
     with tab_interactive:
+        st.caption(
+            ":material/lightbulb: **Tip:** Scroll to zoom the X-axis (Iterations) and drag to pan. "
+            "Vertical zooming is disabled to preserve the log-scale perspective."
+        )
         for idx, item in enumerate(parsed_items):
             name = str(item["name"])
             file_id = str(item["file_id"])
@@ -705,7 +709,7 @@ def main() -> None:
                             delta_color="inverse",
                             border=True,
                             chart_data=sparkline_data,
-                            help=f"Change from initial iteration ({first_val:.4e})",
+                            help=f"Change from initial iteration ({first_val:.4e}). 'OoM' indicates Orders of Magnitude.",
                         )
 
             col_config = {c: st.column_config.NumberColumn(format="%.4e", help=f"Residual values for the '{c}' field") for c in valid_cols}


### PR DESCRIPTION
Added a helpful caption to the Interactive Plot tab explaining the scroll-to-zoom and drag-to-pan interactions, and clarified the 'OoM' abbreviation in the metric tooltip. Also recorded a new journal entry about exposing invisible chart interactions.

---
*PR created automatically by Jules for task [12347277027803263521](https://jules.google.com/task/12347277027803263521) started by @kastnerp*