### PR TITLE
🎨 Palette: Expose Interactive Chart Cursor & Add Sticky Logo Navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,15 @@
 ## 2026-05-19 - Expose Invisible Interactions (Zoom/Pan) in Charts
 **Learning:** Native chart interactions like scrolling to zoom or dragging to pan are completely invisible affordances. Users may not realize they can interact with the visualization, especially when specific axes are constrained (e.g., vertical zooming disabled).
 **Action:** Always provide explicit, concise instructions (e.g., via `st.caption` with an icon) near the interactive chart explaining how to navigate the visualization. This ensures that powerful interactions are discoverable rather than hidden.
+
+## 2026-05-20 - Expose Interactive Chart Elements with Cursor
+**Learning:** By default, interactive marks (like lines or points with tooltips) in Altair/Vega-Lite render with a standard text or default cursor arrow. Sighted users lack an immediate, intuitive visual affordance indicating that the chart elements support hover states or tooltips.
+**Action:** When building interactive Altair charts, explicitly set `cursor="pointer"` on the primary chart mark (e.g., `chart.mark_line(cursor="pointer")`). This subtle interaction cue significantly improves the discoverability of tooltips and hover behaviors.
+
+## 2026-05-20 - Sticky Brand Navigation with st.logo
+**Learning:** In long-scrolling Streamlit applications, users can easily lose the context of the overarching application or miss an intuitive "escape hatch" to return to the home page or reset the app state. Standard titles scroll out of view.
+**Action:** Utilize `st.logo(..., link="...")` near the top of the application script to provide a persistent, sticky brand icon in the upper left corner of both the main body and the sidebar. Linking it to the app's canonical URL turns it into an intuitive, always-accessible "Home/Reset" affordance.
+
+## 2026-05-20 - st.logo Does Not Support Material Icons
+**Learning:** While many Streamlit components (like `st.button`, `st.header`, `st.toast`) natively support rendering Material Design icons via the `":material/icon_name:"` string syntax, the `st.logo` function **does not**. Passing a material icon string to `st.logo` causes Streamlit to interpret it as a local file path, resulting in a fatal `FileNotFoundError` that crashes the entire application.
+**Action:** Always provide a valid image URL (e.g., `https://...`) or a relative file path (e.g., `"./static/logo.png"`) to `st.logo`. Do not attempt to use Streamlit's Material Icon syntax here.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -262,7 +262,7 @@ def build_chart(data: pd.DataFrame, *, interactive: bool, height: int, accessibl
 
     chart = (
         alt.Chart(long_frame)
-        .mark_line()
+        .mark_line(cursor="pointer")
         .encode(**encode_args)
         .add_params(selection, hover)
         .properties(
@@ -434,6 +434,7 @@ def get_file_icon(filename: str) -> str:
 
 def main() -> None:
     st.set_page_config(page_title=SEO_TITLE, page_icon="📈")
+    st.logo("https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/solid/chart-line.svg", link=SEO_CANONICAL_URL)
     inject_seo_metadata()
     st.title(":material/monitoring: Plot OpenFOAM Residuals")
     st.caption(


### PR DESCRIPTION
- Added a persistent `st.logo` linked to the app canonical URL to provide an intuitive "Home/Reset" affordance.
- Added `cursor="pointer"` to the Altair line chart marks (`mark_line(cursor="pointer")`) to expose hidden interactivity (tooltips/hover states).
- Added corresponding UX learnings to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8676453622246398961](https://jules.google.com/task/8676453622246398961) started by @kastnerp*