### PR TITLE
🎨 Palette: Add contextual tips and expose hidden chart interactions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,10 @@
 ## 2026-05-20 - st.logo Does Not Support Material Icons
 **Learning:** While many Streamlit components (like `st.button`, `st.header`, `st.toast`) natively support rendering Material Design icons via the `":material/icon_name:"` string syntax, the `st.logo` function **does not**. Passing a material icon string to `st.logo` causes Streamlit to interpret it as a local file path, resulting in a fatal `FileNotFoundError` that crashes the entire application.
 **Action:** Always provide a valid image URL (e.g., `https://...`) or a relative file path (e.g., `"./static/logo.png"`) to `st.logo`. Do not attempt to use Streamlit's Material Icon syntax here.
+## 2026-05-21 - Expose Hidden Double-Click to Reset Interactions
+**Learning:** In interactive data visualizations like Altair, powerful interactions such as "double-click to reset zoom" are completely invisible to users unless explicitly stated. This can leave users stranded if they accidentally pan or zoom too far.
+**Action:** Always provide explicit UI instructions (e.g. `st.caption`) near the interactive chart explaining how to reset the visualization. This ensures that the interaction is discoverable and provides an immediate escape hatch for users exploring the data.
+
+## 2026-05-21 - Provide Contextual Guidance in Tabbed Interfaces
+**Learning:** When organizing distinct workflows (like interactive vs. static views) into tabbed interfaces, users may not immediately grasp the intended use case for each tab.
+**Action:** Use `st.caption` with contextual Material icons at the top of each tab block to briefly explain the tab's purpose (e.g. "These plots are ideal for static reports"). This sets user expectations and improves overall application scannability.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -609,7 +609,7 @@ def main() -> None:
     with tab_interactive:
         st.caption(
             ":material/lightbulb: **Tip:** Scroll to zoom the X-axis (Iterations) and drag to pan. "
-            "Vertical zooming is disabled to preserve the log-scale perspective."
+            "Vertical zooming is disabled to preserve the log-scale perspective. Double-click to reset the view."
         )
         for idx, item in enumerate(parsed_items):
             name = str(item["name"])
@@ -626,6 +626,10 @@ def main() -> None:
                 st.divider()
 
     with tab_static:
+        st.caption(
+            ":material/image: **Static Plots:** These high-resolution Matplotlib figures are ideal for "
+            "reports and publications. Use the sidebar to adjust their dimensions and styling."
+        )
         static_images: list[tuple[str, bytes]] = []
 
         for idx, item in enumerate(parsed_items):
@@ -675,6 +679,10 @@ def main() -> None:
             )
 
     with tab_table:
+        st.caption(
+            ":material/table_view: **Raw Data & Metrics:** Inspect the final convergence metrics and raw "
+            "residual values. Export the data to CSV for further analysis."
+        )
         all_csvs: list[tuple[str, bytes]] = []
         for idx, item in enumerate(parsed_items):
             name = str(item["name"])


### PR DESCRIPTION
💡 **What:** Added descriptive `st.caption` elements to the tops of all main application tabs, including exposing the "double-click to reset" functionality in the interactive Altair chart.
🎯 **Why:** Users need contextual guidance when navigating tabbed interfaces to understand the distinct purpose of each view. Additionally, powerful interactions like resetting an Altair chart zoom state are completely invisible by default, which can strand users if they accidentally pan/zoom out of bounds.
♿ **Accessibility:** Providing explicit, visible text instructions for interactions ensures they are discoverable to all users, rather than relying on assumed knowledge or exploratory clicks.

---
*PR created automatically by Jules for task [11635381985280188378](https://jules.google.com/task/11635381985280188378) started by @kastnerp*